### PR TITLE
link 1

### DIFF
--- a/src/main/kotlin/sigma/BinaryOperationPrototype.kt
+++ b/src/main/kotlin/sigma/BinaryOperationPrototype.kt
@@ -1,0 +1,57 @@
+package sigma
+
+import sigma.values.Symbol
+
+data class BinaryOperationPrototype(
+    val functionName: String,
+    val leftArgumentName: String,
+    val rightArgumentName: String,
+) {
+    companion object {
+        val multiplication = BinaryOperationPrototype(
+            functionName = "mul", leftArgumentName = "multiplier", rightArgumentName = "multiplicand"
+        )
+
+        val addition = BinaryOperationPrototype(
+            functionName = "add", leftArgumentName = "augend", rightArgumentName = "addend"
+        )
+
+        val subtraction = BinaryOperationPrototype(
+            functionName = "sub", leftArgumentName = "minuend", rightArgumentName = "subtrahend"
+        )
+
+        val division = BinaryOperationPrototype(
+            functionName = "div", leftArgumentName = "dividend", rightArgumentName = "divisor"
+        )
+
+        val lessThan = BinaryOperationPrototype(
+            functionName = "lt", leftArgumentName = "left", rightArgumentName = "right"
+        )
+
+        val lessThanOrEqual = BinaryOperationPrototype(
+            functionName = "lt", leftArgumentName = "left", rightArgumentName = "right"
+        )
+
+        val greaterThan = BinaryOperationPrototype(
+            functionName = "gt", leftArgumentName = "left", rightArgumentName = "right"
+        )
+
+        val greaterThanOrEqual = BinaryOperationPrototype(
+            functionName = "gte", leftArgumentName = "left", rightArgumentName = "right"
+        )
+
+        val equals = BinaryOperationPrototype(
+            functionName = "eq", leftArgumentName = "first", rightArgumentName = "second"
+        )
+
+        val link = BinaryOperationPrototype(
+            functionName = "link", leftArgumentName = "primary", rightArgumentName = "secondary"
+        )
+    }
+
+    val leftArgument: Symbol
+        get() = Symbol.of(leftArgumentName)
+
+    val rightArgument: Symbol
+        get() = Symbol.of(rightArgumentName)
+}

--- a/src/main/kotlin/sigma/GlobalContext.kt
+++ b/src/main/kotlin/sigma/GlobalContext.kt
@@ -6,6 +6,7 @@ import sigma.values.Symbol
 import sigma.values.tables.Table
 import sigma.values.UndefinedValue
 import sigma.values.Value
+import sigma.values.tables.Scope
 
 object IntegerTable : Table() {
     override fun read(argument: Value): Value? {
@@ -18,8 +19,8 @@ object IntegerTable : Table() {
     override fun dumpContent(): String = "(integer table)"
 }
 
-private object BuiltinContext : Table() {
-    private val builtins = mapOf(
+private object BuiltinContext : Scope() {
+    private val builtins: Map<Symbol, Value> = mapOf(
         Symbol.of("false") to BoolValue.False,
         Symbol.of("true") to BoolValue.True,
         Symbol.of("if") to BoolValue.If,
@@ -37,12 +38,7 @@ private object BuiltinContext : Table() {
         Symbol.of("isUndefined") to UndefinedValue.IsUndefined,
     )
 
-    override fun read(
-        argument: Value,
-    ): Value? = when (argument) {
-        !is Symbol -> null
-        else -> builtins[argument]
-    }
+    override fun get(name: Symbol): Value? = builtins[name]
 
     override fun dumpContent(): String = "(built-in context)"
 }

--- a/src/main/kotlin/sigma/expressions/Application.kt
+++ b/src/main/kotlin/sigma/expressions/Application.kt
@@ -1,5 +1,6 @@
 package sigma.expressions
 
+import sigma.BinaryOperationPrototype
 import sigma.Thunk
 import sigma.values.FunctionValue
 import sigma.values.IntValue
@@ -26,16 +27,16 @@ data class Application(
             val rightExpression = Expression.build(ctx.right)
 
             val prototype = when (ctx.operator.type) {
-                SigmaLexer.Asterisk -> IntValue.multiplication
-                SigmaLexer.Plus -> IntValue.addition
-                SigmaLexer.Minus -> IntValue.subtraction
-                SigmaLexer.Slash -> IntValue.division
-                SigmaLexer.Lt -> IntValue.lessThan
-                SigmaLexer.Lte -> IntValue.lessThanOrEqual
-                SigmaLexer.Gt -> IntValue.greaterThan
-                SigmaLexer.Gte -> IntValue.greaterThanOrEqual
-                SigmaLexer.Equals -> IntValue.equals
-                SigmaLexer.Link -> IntValue.link
+                SigmaLexer.Asterisk -> BinaryOperationPrototype.multiplication
+                SigmaLexer.Plus -> BinaryOperationPrototype.addition
+                SigmaLexer.Minus -> BinaryOperationPrototype.subtraction
+                SigmaLexer.Slash -> BinaryOperationPrototype.division
+                SigmaLexer.Lt -> BinaryOperationPrototype.lessThan
+                SigmaLexer.Lte -> BinaryOperationPrototype.lessThanOrEqual
+                SigmaLexer.Gt -> BinaryOperationPrototype.greaterThan
+                SigmaLexer.Gte -> BinaryOperationPrototype.greaterThanOrEqual
+                SigmaLexer.Equals -> BinaryOperationPrototype.equals
+                SigmaLexer.Link -> BinaryOperationPrototype.link
                 else -> throw UnsupportedOperationException()
             }
 

--- a/src/main/kotlin/sigma/expressions/Application.kt
+++ b/src/main/kotlin/sigma/expressions/Application.kt
@@ -1,5 +1,6 @@
 package sigma.expressions
 
+import sigma.Thunk
 import sigma.values.FunctionValue
 import sigma.values.IntValue
 import sigma.values.Symbol
@@ -68,26 +69,16 @@ data class Application(
 
     override fun evaluate(
         context: Table,
-    ): Value {
-        ++depth
-
-//        if (depth > 1000) {
-//            println("Going deep...")
-//        }
-
+    ): Thunk {
         val subjectValue = subject.evaluate(context = context)
 
         if (subjectValue !is FunctionValue) throw IllegalStateException("Subject $subjectValue is not a function")
 
         val argumentValue = argument.evaluate(context = context)
 
-//        println("Calling ${subject.dump()} with argument ${argumentValue.dump()}")
-
         val image = subjectValue.apply(
-            argument = argumentValue,
-        ) ?: throw IllegalStateException("Subject is not defined over ${argumentValue.dump()}")
-
-        --depth
+            argument = argumentValue.obtain(),
+        )
 
         return image
     }

--- a/src/main/kotlin/sigma/expressions/DictConstructor.kt
+++ b/src/main/kotlin/sigma/expressions/DictConstructor.kt
@@ -5,6 +5,7 @@ import sigma.parser.antlr.SigmaParser
 import sigma.parser.antlr.SigmaParser.DictArrayAltContext
 import sigma.parser.antlr.SigmaParser.DictContext
 import sigma.parser.antlr.SigmaParserBaseVisitor
+import sigma.values.PrimitiveValue
 import sigma.values.tables.DictTable
 
 data class DictConstructor(
@@ -65,7 +66,7 @@ data class DictConstructor(
     ): DictTable = DictTable(
         environment = context,
         associations = content.mapKeys {
-            it.key.evaluate(context = context)
+            it.key.evaluate(context = context) as PrimitiveValue
         },
     )
 }

--- a/src/main/kotlin/sigma/expressions/DictConstructor.kt
+++ b/src/main/kotlin/sigma/expressions/DictConstructor.kt
@@ -1,11 +1,11 @@
 package sigma.expressions
 
-import sigma.values.tables.DictAssociativeTable
 import sigma.values.tables.Table
 import sigma.parser.antlr.SigmaParser
 import sigma.parser.antlr.SigmaParser.DictArrayAltContext
 import sigma.parser.antlr.SigmaParser.DictContext
 import sigma.parser.antlr.SigmaParserBaseVisitor
+import sigma.values.tables.DictTable
 
 data class DictConstructor(
     val content: Map<Expression, Expression>,
@@ -62,7 +62,7 @@ data class DictConstructor(
 
     override fun evaluate(
         context: Table,
-    ): DictAssociativeTable = DictAssociativeTable(
+    ): DictTable = DictTable(
         environment = context,
         associations = content.mapKeys {
             it.key.evaluate(context = context)

--- a/src/main/kotlin/sigma/expressions/Expression.kt
+++ b/src/main/kotlin/sigma/expressions/Expression.kt
@@ -4,6 +4,7 @@ import org.antlr.v4.runtime.CharStreams
 import org.antlr.v4.runtime.CommonTokenStream
 import org.antlr.v4.runtime.ParserRuleContext
 import sigma.GlobalContext
+import sigma.Thunk
 import sigma.parser.antlr.SigmaLexer
 import sigma.parser.antlr.SigmaParser
 import sigma.parser.antlr.SigmaParser.AbstractionAltContext
@@ -97,7 +98,7 @@ sealed interface Expression {
     // Thought: Should `context` be `environment`?
     fun evaluate(
         context: Table = GlobalContext,
-    ): Value
+    ): Thunk
 
     fun dump(): String
 }

--- a/src/main/kotlin/sigma/expressions/LetExpression.kt
+++ b/src/main/kotlin/sigma/expressions/LetExpression.kt
@@ -1,5 +1,6 @@
 package sigma.expressions
 
+import sigma.Thunk
 import sigma.values.tables.LoopedScope
 import sigma.values.tables.Table
 import sigma.values.Value
@@ -24,7 +25,7 @@ data class LetExpression(
 
     override fun evaluate(
         context: Table,
-    ): Value {
+    ): Thunk {
         val scope = LoopedScope(
             context = context,
             declarations = declarations.associate {

--- a/src/main/kotlin/sigma/expressions/LetExpression.kt
+++ b/src/main/kotlin/sigma/expressions/LetExpression.kt
@@ -1,6 +1,6 @@
 package sigma.expressions
 
-import sigma.LoopedScope
+import sigma.values.tables.LoopedScope
 import sigma.values.tables.Table
 import sigma.values.Value
 import sigma.parser.antlr.SigmaParser.LetExpressionContext

--- a/src/main/kotlin/sigma/expressions/Reference.kt
+++ b/src/main/kotlin/sigma/expressions/Reference.kt
@@ -1,5 +1,6 @@
 package sigma.expressions
 
+import sigma.Thunk
 import sigma.values.Symbol
 import sigma.values.tables.Table
 import sigma.values.Value
@@ -18,7 +19,7 @@ data class Reference(
 
     override fun evaluate(
         context: Table,
-    ): Value = context.apply(referee)
+    ): Thunk = context.apply(referee)
 
     override fun dump(): String = referee.dump()
 }

--- a/src/main/kotlin/sigma/values/BoolValue.kt
+++ b/src/main/kotlin/sigma/values/BoolValue.kt
@@ -1,5 +1,7 @@
 package sigma.values
 
+import sigma.Thunk
+
 data class BoolValue(
     val value: Boolean,
 ) : PrimitiveValue() {
@@ -14,7 +16,7 @@ data class BoolValue(
             val test = argument as BoolValue
 
             return object : ComputableFunctionValue() {
-                override fun apply(argument: Value): Value {
+                override fun apply(argument: Value): Thunk {
                     val branches = argument as FunctionValue
 
                     return when {

--- a/src/main/kotlin/sigma/values/Closure.kt
+++ b/src/main/kotlin/sigma/values/Closure.kt
@@ -1,6 +1,7 @@
 package sigma.values
 
 import sigma.ArgumentTable
+import sigma.Thunk
 import sigma.expressions.Expression
 import sigma.values.tables.ChainedTable
 import sigma.values.tables.Table
@@ -12,7 +13,7 @@ class Closure(
 ) : ComputableFunctionValue() {
     override fun apply(
         argument: Value,
-    ): Value = image.evaluate(
+    ): Thunk = image.evaluate(
         context = ChainedTable(
             context = context,
             table = ArgumentTable(

--- a/src/main/kotlin/sigma/values/FunctionValue.kt
+++ b/src/main/kotlin/sigma/values/FunctionValue.kt
@@ -1,5 +1,6 @@
 package sigma.values
 
+import sigma.Thunk
 import sigma.values.tables.ChainedTable
 import sigma.values.tables.Table
 
@@ -24,5 +25,5 @@ abstract class FunctionValue : Value() {
 
     abstract fun apply(
         argument: Value,
-    ): Value
+    ): Thunk
 }

--- a/src/main/kotlin/sigma/values/IntValue.kt
+++ b/src/main/kotlin/sigma/values/IntValue.kt
@@ -1,81 +1,10 @@
 package sigma.values
 
+import sigma.BinaryOperationPrototype
+
 data class IntValue(
     val value: Int,
 ) : PrimitiveValue() {
-    data class BinaryOperationPrototype(
-        val functionName: String,
-        val leftArgumentName: String,
-        val rightArgumentName: String,
-    ) {
-        val leftArgument: Symbol
-            get() = Symbol.of(leftArgumentName)
-
-        val rightArgument: Symbol
-            get() = Symbol.of(rightArgumentName)
-    }
-
-    companion object {
-        val multiplication = BinaryOperationPrototype(
-            functionName = "mul",
-            leftArgumentName = "multiplier",
-            rightArgumentName = "multiplicand"
-        )
-
-        val addition = BinaryOperationPrototype(
-            functionName = "add",
-            leftArgumentName = "augend",
-            rightArgumentName = "addend"
-        )
-
-        val subtraction = BinaryOperationPrototype(
-            functionName = "sub",
-            leftArgumentName = "minuend",
-            rightArgumentName = "subtrahend"
-        )
-
-        val division = BinaryOperationPrototype(
-            functionName = "div",
-            leftArgumentName = "dividend",
-            rightArgumentName = "divisor"
-        )
-
-        val lessThan = BinaryOperationPrototype(
-            functionName = "lt",
-            leftArgumentName = "left",
-            rightArgumentName = "right"
-        )
-
-        val lessThanOrEqual = BinaryOperationPrototype(
-            functionName = "lt",
-            leftArgumentName = "left",
-            rightArgumentName = "right"
-        )
-
-        val greaterThan = BinaryOperationPrototype(
-            functionName = "gt",
-            leftArgumentName = "left",
-            rightArgumentName = "right"
-        )
-
-        val greaterThanOrEqual = BinaryOperationPrototype(
-            functionName = "gte",
-            leftArgumentName = "left",
-            rightArgumentName = "right"
-        )
-
-        val equals = BinaryOperationPrototype(
-            functionName = "eq",
-            leftArgumentName = "first",
-            rightArgumentName = "second"
-        )
-
-        val link = BinaryOperationPrototype(
-            functionName = "link",
-            leftArgumentName = "primary",
-            rightArgumentName = "secondary"
-        )
-    }
 
     abstract class BinaryIntFunction : ComputableFunctionValue() {
         override fun apply(argument: Value): Value {
@@ -101,7 +30,7 @@ data class IntValue(
     }
 
     object Mul : BinaryIntFunction() {
-        override val prototype: BinaryOperationPrototype = multiplication
+        override val prototype: BinaryOperationPrototype = BinaryOperationPrototype.multiplication
 
         override fun calculate(
             left: Int, right: Int,
@@ -109,7 +38,7 @@ data class IntValue(
     }
 
     object Div : BinaryIntFunction() {
-        override val prototype: BinaryOperationPrototype = division
+        override val prototype: BinaryOperationPrototype = BinaryOperationPrototype.division
 
         override fun calculate(
             left: Int, right: Int,
@@ -117,7 +46,7 @@ data class IntValue(
     }
 
     object Add : BinaryIntFunction() {
-        override val prototype: BinaryOperationPrototype = addition
+        override val prototype: BinaryOperationPrototype = BinaryOperationPrototype.addition
 
         override fun calculate(
             left: Int, right: Int,
@@ -125,7 +54,7 @@ data class IntValue(
     }
 
     object Sub : BinaryIntFunction() {
-        override val prototype: BinaryOperationPrototype = subtraction
+        override val prototype: BinaryOperationPrototype = BinaryOperationPrototype.subtraction
 
         override fun calculate(
             left: Int, right: Int,
@@ -143,7 +72,7 @@ data class IntValue(
     }
 
     object Eq : BinaryIntFunction() {
-        override val prototype: BinaryOperationPrototype = equals
+        override val prototype: BinaryOperationPrototype = BinaryOperationPrototype.equals
 
         override fun calculate(
             left: Int,
@@ -152,7 +81,7 @@ data class IntValue(
     }
 
     object Lt : BinaryIntFunction() {
-        override val prototype: BinaryOperationPrototype = lessThan
+        override val prototype: BinaryOperationPrototype = BinaryOperationPrototype.lessThan
 
         override fun calculate(
             left: Int,
@@ -161,7 +90,7 @@ data class IntValue(
     }
 
     object Lte : BinaryIntFunction() {
-        override val prototype: BinaryOperationPrototype = lessThanOrEqual
+        override val prototype: BinaryOperationPrototype = BinaryOperationPrototype.lessThanOrEqual
 
         override fun calculate(
             left: Int,
@@ -170,7 +99,7 @@ data class IntValue(
     }
 
     object Gt : BinaryIntFunction() {
-        override val prototype: BinaryOperationPrototype = greaterThan
+        override val prototype: BinaryOperationPrototype = BinaryOperationPrototype.greaterThan
 
         override fun calculate(
             left: Int,
@@ -179,7 +108,7 @@ data class IntValue(
     }
 
     object Gte : BinaryIntFunction() {
-        override val prototype: BinaryOperationPrototype = greaterThanOrEqual
+        override val prototype: BinaryOperationPrototype = BinaryOperationPrototype.greaterThanOrEqual
 
         override fun calculate(
             left: Int,

--- a/src/main/kotlin/sigma/values/UndefinedValue.kt
+++ b/src/main/kotlin/sigma/values/UndefinedValue.kt
@@ -1,5 +1,7 @@
 package sigma.values
 
+import sigma.Thunk
+
 class UndefinedValue private constructor(
     val name: Value? = null,
 ) : Value() {
@@ -14,7 +16,7 @@ class UndefinedValue private constructor(
     object IsUndefined : ComputableFunctionValue() {
         override fun apply(
             argument: Value,
-        ): Value = BoolValue(argument is UndefinedValue)
+        ): Thunk = BoolValue(argument is UndefinedValue)
 
         override fun dump(): String = "(isUndefined)"
     }

--- a/src/main/kotlin/sigma/values/tables/ChainedTable.kt
+++ b/src/main/kotlin/sigma/values/tables/ChainedTable.kt
@@ -1,5 +1,6 @@
 package sigma.values.tables
 
+import sigma.Thunk
 import sigma.values.Value
 
 class ChainedTable(
@@ -15,5 +16,9 @@ class ChainedTable(
 
     override fun read(
         argument: Value,
-    ): Value? = table.read(argument = argument) ?: context.read(argument = argument)
+    ): Thunk? = table.read(
+        argument = argument,
+    ) ?: context.read(
+        argument = argument,
+    )
 }

--- a/src/main/kotlin/sigma/values/tables/DictAssociativeTable.kt
+++ b/src/main/kotlin/sigma/values/tables/DictAssociativeTable.kt
@@ -1,9 +1,0 @@
-package sigma.values.tables
-
-import sigma.expressions.Expression
-import sigma.values.Value
-
-class DictAssociativeTable(
-    override val environment: Table,
-    associations: Map<Value, Expression>,
-) : AssociativeTable(associations = associations)

--- a/src/main/kotlin/sigma/values/tables/DictTable.kt
+++ b/src/main/kotlin/sigma/values/tables/DictTable.kt
@@ -1,5 +1,6 @@
 package sigma.values.tables
 
+import sigma.Thunk
 import sigma.expressions.Expression
 import sigma.values.PrimitiveValue
 import sigma.values.Symbol
@@ -11,7 +12,7 @@ class DictTable(
 ) : Table() {
     override fun read(
         argument: Value,
-    ): Value? = associations[argument]?.evaluate(
+    ): Thunk? = associations[argument]?.evaluate(
         context = environment,
     )
 
@@ -24,7 +25,7 @@ class DictTable(
 
         return entries.joinToString(separator = ", ") {
             val keyStr = dumpKey(key = it.key)
-            val imageStr = it.value.dump()
+            val imageStr = it.value.obtain().dump()
 
             "$keyStr = $imageStr"
         }

--- a/src/main/kotlin/sigma/values/tables/DictTable.kt
+++ b/src/main/kotlin/sigma/values/tables/DictTable.kt
@@ -4,7 +4,8 @@ import sigma.expressions.Expression
 import sigma.values.Symbol
 import sigma.values.Value
 
-abstract class AssociativeTable(
+class DictTable(
+    private val environment: Table,
     private val associations: Map<Value, Expression>,
 ) : Table() {
     override fun read(
@@ -34,6 +35,4 @@ abstract class AssociativeTable(
         is Symbol -> key.dump()
         else -> "[${key.dump()}]"
     }
-
-    abstract val environment: Table
 }

--- a/src/main/kotlin/sigma/values/tables/DictTable.kt
+++ b/src/main/kotlin/sigma/values/tables/DictTable.kt
@@ -1,12 +1,13 @@
 package sigma.values.tables
 
 import sigma.expressions.Expression
+import sigma.values.PrimitiveValue
 import sigma.values.Symbol
 import sigma.values.Value
 
 class DictTable(
     private val environment: Table,
-    private val associations: Map<Value, Expression>,
+    private val associations: Map<PrimitiveValue, Expression>,
 ) : Table() {
     override fun read(
         argument: Value,

--- a/src/main/kotlin/sigma/values/tables/LoopedScope.kt
+++ b/src/main/kotlin/sigma/values/tables/LoopedScope.kt
@@ -1,5 +1,6 @@
 package sigma.values.tables
 
+import sigma.Thunk
 import sigma.expressions.Expression
 import sigma.values.Symbol
 import sigma.values.Value
@@ -12,7 +13,7 @@ class LoopedScope(
 ) : Scope() {
     private val environment: Table = this.chainWith(context)
 
-    override fun get(name: Symbol): Value? {
+    override fun get(name: Symbol): Thunk? {
         val value = declarations[name] ?: return context.read(
             argument = name,
         )

--- a/src/main/kotlin/sigma/values/tables/LoopedScope.kt
+++ b/src/main/kotlin/sigma/values/tables/LoopedScope.kt
@@ -1,21 +1,20 @@
-package sigma
+package sigma.values.tables
 
 import sigma.expressions.Expression
 import sigma.values.Symbol
-import sigma.values.tables.Table
 import sigma.values.Value
+
+
 
 class LoopedScope(
     private val context: Table,
     private val declarations: Map<Symbol, Expression>,
-) : Table() {
+) : Scope() {
     private val environment: Table = this.chainWith(context)
 
-    override fun read(argument: Value): Value? {
-        if (argument !is Symbol) return null
-
-        val value = declarations[argument] ?: return context.read(
-            argument = argument,
+    override fun get(name: Symbol): Value? {
+        val value = declarations[name] ?: return context.read(
+            argument = name,
         )
 
         return value.evaluate(context = environment)

--- a/src/main/kotlin/sigma/values/tables/Scope.kt
+++ b/src/main/kotlin/sigma/values/tables/Scope.kt
@@ -1,14 +1,15 @@
 package sigma.values.tables
 
+import sigma.Thunk
 import sigma.values.Symbol
 import sigma.values.Value
 
 abstract class Scope : Table() {
-    final override fun read(argument: Value): Value? {
+    final override fun read(argument: Value): Thunk? {
         if (argument !is Symbol) return null
 
         return get(name = argument)
     }
 
-    abstract fun get(name: Symbol): Value?
+    abstract fun get(name: Symbol): Thunk?
 }

--- a/src/main/kotlin/sigma/values/tables/Scope.kt
+++ b/src/main/kotlin/sigma/values/tables/Scope.kt
@@ -1,0 +1,14 @@
+package sigma.values.tables
+
+import sigma.values.Symbol
+import sigma.values.Value
+
+abstract class Scope : Table() {
+    final override fun read(argument: Value): Value? {
+        if (argument !is Symbol) return null
+
+        return get(name = argument)
+    }
+
+    abstract fun get(name: Symbol): Value?
+}

--- a/src/main/kotlin/sigma/values/tables/Table.kt
+++ b/src/main/kotlin/sigma/values/tables/Table.kt
@@ -1,5 +1,6 @@
 package sigma.values.tables
 
+import sigma.Thunk
 import sigma.values.FunctionValue
 import sigma.values.UndefinedValue
 import sigma.values.Value
@@ -8,7 +9,7 @@ import sigma.values.Value
 abstract class Table : FunctionValue() {
     final override fun apply(
         argument: Value,
-    ): Value = read(
+    ): Thunk = read(
         argument = argument,
     ) ?: UndefinedValue.withName(
         name = argument,
@@ -33,7 +34,7 @@ abstract class Table : FunctionValue() {
     // Idea: Rename to `key`?
     abstract fun read(
         argument: Value,
-    ): Value?
+    ): Thunk?
 
     abstract fun dumpContent(): String?
 }

--- a/src/test/kotlin/sigma/programs/euler/EulerProblemsTests.kt
+++ b/src/test/kotlin/sigma/programs/euler/EulerProblemsTests.kt
@@ -69,7 +69,7 @@ private fun solveProblem(n: Int): Value {
 
     val result = root.evaluate()
 
-    return result
+    return result.obtain()
 }
 
 private fun getResourceAsText(


### PR DESCRIPTION
- Extract the `Scope` class
- Nuke `DictAssociativeTable`
- Make `DictTable` use primitive keys
- Use `Thunk` in the place of `Value` in some contexts
- Redefine the `link` standard function
- Extract `BinaryOperationPrototype` to a separate file
