### PR TITLE
static scope 2

### DIFF
--- a/src/main/kotlin/sigma/StaticScope.kt
+++ b/src/main/kotlin/sigma/StaticScope.kt
@@ -1,0 +1,29 @@
+package sigma
+
+import sigma.values.Symbol
+import sigma.types.Type
+
+interface StaticTypeScope {
+    fun getType(typeName: Symbol): Type?
+}
+
+interface StaticValueScope {
+    fun getValueType(valueName: Symbol): Type?
+}
+
+data class StaticScope(
+    val typeScope: StaticTypeScope,
+    val valueScope: StaticValueScope,
+) : StaticTypeScope, StaticValueScope {
+    override fun getType(
+        typeName: Symbol,
+    ): Type? = typeScope.getType(
+        typeName = typeName,
+    )
+
+    override fun getValueType(
+        valueName: Symbol,
+    ): Type? = valueScope.getValueType(
+        valueName = valueName,
+    )
+}

--- a/src/main/kotlin/sigma/TypeContext.kt
+++ b/src/main/kotlin/sigma/TypeContext.kt
@@ -1,19 +1,22 @@
 package sigma
 
 import sigma.types.IntType
+import sigma.types.SymbolType
 import sigma.types.Type
 import sigma.values.Symbol
 
-interface TypeContext {
-    fun getType(name: Symbol): Type?
-}
+private val builtinTypes = mapOf(
+    Symbol.of("Int") to IntType,
+    Symbol.of("Symbol") to SymbolType,
+)
 
-object GlobalTypeContext : TypeContext {
-    private val builtinTypes = mapOf(
-        Symbol.of("Int") to IntType,
-    )
-
-    override fun getType(
-        name: Symbol,
-    ): Type? = builtinTypes[name]
-}
+val GlobalStaticScope = StaticScope(
+    typeScope = object : StaticTypeScope {
+        override fun getType(
+            typeName: Symbol,
+        ): Type? = builtinTypes[typeName]
+    },
+    valueScope = object : StaticValueScope {
+        override fun getValueType(valueName: Symbol): Type? = null
+    },
+)

--- a/src/main/kotlin/sigma/TypeExpression.kt
+++ b/src/main/kotlin/sigma/TypeExpression.kt
@@ -14,6 +14,6 @@ sealed interface TypeExpression {
     }
 
     fun evaluate(
-        context: TypeContext,
+        context: StaticScope,
     ): Type?
 }

--- a/src/main/kotlin/sigma/TypeReference.kt
+++ b/src/main/kotlin/sigma/TypeReference.kt
@@ -7,8 +7,8 @@ data class TypeReference(
     val referee: Symbol,
 ) : TypeExpression {
     override fun evaluate(
-        context: TypeContext,
+        context: StaticScope,
     ): Type? = context.getType(
-        name = referee,
+        typeName = referee,
     )
 }

--- a/src/main/kotlin/sigma/expressions/Abstraction.kt
+++ b/src/main/kotlin/sigma/expressions/Abstraction.kt
@@ -1,5 +1,6 @@
 package sigma.expressions
 
+import sigma.StaticScope
 import sigma.values.Closure
 import sigma.values.Symbol
 import sigma.values.Value
@@ -21,8 +22,8 @@ data class Abstraction(
         )
     }
 
-    override fun inferType(): Type = FunctionType(
-        imageType = image.inferType(),
+    override fun inferType(scope: StaticScope): Type = FunctionType(
+        imageType = image.inferType(scope = scope),
     )
 
     override fun evaluate(

--- a/src/main/kotlin/sigma/expressions/Abstraction.kt
+++ b/src/main/kotlin/sigma/expressions/Abstraction.kt
@@ -26,9 +26,9 @@ data class Abstraction(
     )
 
     override fun evaluate(
-        context: Scope,
+        scope: Scope,
     ): Value = Closure(
-        context = context,
+        context = scope,
         argumentName = argumentName,
         image = image,
     )

--- a/src/main/kotlin/sigma/expressions/Application.kt
+++ b/src/main/kotlin/sigma/expressions/Application.kt
@@ -1,6 +1,7 @@
 package sigma.expressions
 
 import sigma.BinaryOperationPrototype
+import sigma.StaticScope
 import sigma.Thunk
 import sigma.parser.antlr.SigmaLexer
 import sigma.parser.antlr.SigmaParser.BinaryOperationAltContext
@@ -74,8 +75,10 @@ data class Application(
         )
     }
 
-    override fun inferType(): Type {
-        val subjectType = subject.inferType() as? FunctionType ?: throw TypeError(
+    override fun inferType(scope: StaticScope): Type {
+        val subjectType = subject.inferType(
+            scope = scope,
+        ) as? FunctionType ?: throw TypeError(
             message = "Only functions can be called",
         )
 

--- a/src/main/kotlin/sigma/expressions/Application.kt
+++ b/src/main/kotlin/sigma/expressions/Application.kt
@@ -83,13 +83,13 @@ data class Application(
     }
 
     override fun evaluate(
-        context: Scope,
+        scope: Scope,
     ): Thunk {
-        val subjectValue = subject.evaluate(context = context).obtain()
+        val subjectValue = subject.evaluate(scope = scope).obtain()
 
         if (subjectValue !is FunctionValue) throw IllegalStateException("Subject $subjectValue is not a function")
 
-        val argumentValue = argument.evaluate(context = context)
+        val argumentValue = argument.evaluate(scope = scope)
 
         // Thought: Obtaining argument here might not be lazy enough
         val image = subjectValue.apply(

--- a/src/main/kotlin/sigma/expressions/Declaration.kt
+++ b/src/main/kotlin/sigma/expressions/Declaration.kt
@@ -1,14 +1,24 @@
 package sigma.expressions
 
+import sigma.StaticScope
 import sigma.TypeExpression
 import sigma.values.Symbol
 import sigma.parser.antlr.SigmaParser.DeclarationContext
+import sigma.types.Type
 
 data class Declaration(
     val name: Symbol,
     val valueType: TypeExpression? = null,
     val value: Expression,
 ) {
+    fun determineType(
+        context: StaticScope,
+    ): Type = valueType?.evaluate(
+        context = context,
+    ) ?: value.inferType(
+        scope = context,
+    )
+
     companion object {
         fun build(
             ctx: DeclarationContext,

--- a/src/main/kotlin/sigma/expressions/DictConstructor.kt
+++ b/src/main/kotlin/sigma/expressions/DictConstructor.kt
@@ -88,11 +88,11 @@ data class DictConstructor(
     override fun inferType(): Type = DictType
 
     override fun evaluate(
-        context: Scope,
+        scope: Scope,
     ): DictTable = DictTable(
         associations = content.associate {
-            val key = it.key.evaluate(context = context).obtain() as PrimitiveValue
-            val value = it.value.bind(scope = context)
+            val key = it.key.evaluate(scope = scope).obtain() as PrimitiveValue
+            val value = it.value.bind(scope = scope)
 
             key to value
         },

--- a/src/main/kotlin/sigma/expressions/DictConstructor.kt
+++ b/src/main/kotlin/sigma/expressions/DictConstructor.kt
@@ -1,5 +1,6 @@
 package sigma.expressions
 
+import sigma.StaticScope
 import sigma.parser.antlr.SigmaParser
 import sigma.parser.antlr.SigmaParser.DictArrayAltContext
 import sigma.parser.antlr.SigmaParser.DictContext
@@ -85,7 +86,7 @@ data class DictConstructor(
 
     override fun dump(): String = "(dict constructor)"
 
-    override fun inferType(): Type = DictType
+    override fun inferType(scope: StaticScope): Type = DictType
 
     override fun evaluate(
         scope: Scope,

--- a/src/main/kotlin/sigma/expressions/Expression.kt
+++ b/src/main/kotlin/sigma/expressions/Expression.kt
@@ -4,6 +4,8 @@ import org.antlr.v4.runtime.CharStreams
 import org.antlr.v4.runtime.CommonTokenStream
 import org.antlr.v4.runtime.ParserRuleContext
 import sigma.GlobalContext
+import sigma.GlobalStaticScope
+import sigma.StaticScope
 import sigma.Thunk
 import sigma.parser.antlr.SigmaLexer
 import sigma.parser.antlr.SigmaParser
@@ -104,9 +106,13 @@ sealed class Expression {
         override fun dump(): String = "(bound thunk)"
     }
 
+    fun obtainType() = inferType(scope = GlobalStaticScope)
+
     fun obtain(): Value = evaluate(scope = GlobalContext).obtain()
 
-    abstract fun inferType(): Type
+    abstract fun inferType(
+        scope: StaticScope,
+    ): Type
 
     abstract fun evaluate(
         scope: Scope,
@@ -114,4 +120,3 @@ sealed class Expression {
 
     abstract fun dump(): String
 }
-

--- a/src/main/kotlin/sigma/expressions/Expression.kt
+++ b/src/main/kotlin/sigma/expressions/Expression.kt
@@ -98,19 +98,18 @@ sealed class Expression {
 
     fun bind(scope: Scope): Thunk = object : Thunk() {
         override fun obtain(): Value = this@Expression.evaluate(
-            context = scope,
+            scope = scope,
         ).obtain()
 
         override fun dump(): String = "(bound thunk)"
     }
 
-    fun obtain(): Value = evaluate(context = GlobalContext).obtain()
+    fun obtain(): Value = evaluate(scope = GlobalContext).obtain()
 
     abstract fun inferType(): Type
 
-    // Thought: Should `context` be `environment`?
     abstract fun evaluate(
-        context: Scope,
+        scope: Scope,
     ): Thunk
 
     abstract fun dump(): String

--- a/src/main/kotlin/sigma/expressions/IntLiteral.kt
+++ b/src/main/kotlin/sigma/expressions/IntLiteral.kt
@@ -26,7 +26,7 @@ data class IntLiteral(
     override fun inferType(): Type = IntType
 
     override fun evaluate(
-        context: Scope,
+        scope: Scope,
     ): Value = value
 
     override fun dump(): String = value.dump()

--- a/src/main/kotlin/sigma/expressions/IntLiteral.kt
+++ b/src/main/kotlin/sigma/expressions/IntLiteral.kt
@@ -1,5 +1,6 @@
 package sigma.expressions
 
+import sigma.StaticScope
 import sigma.parser.antlr.SigmaParser
 import sigma.types.IntType
 import sigma.types.Type
@@ -23,7 +24,7 @@ data class IntLiteral(
         )
     }
 
-    override fun inferType(): Type = IntType
+    override fun inferType(scope: StaticScope): Type = IntType
 
     override fun evaluate(
         scope: Scope,

--- a/src/main/kotlin/sigma/expressions/LetExpression.kt
+++ b/src/main/kotlin/sigma/expressions/LetExpression.kt
@@ -26,17 +26,17 @@ data class LetExpression(
     override fun inferType(): Type = result.inferType()
 
     override fun evaluate(
-        context: Scope,
+        scope: Scope,
     ): Thunk {
         val scope = LoopedScope(
-            context = context,
+            context = scope,
             declarations = declarations.associate {
                 it.name to it.value
             },
         )
 
         return result.evaluate(
-            context = scope,
+            scope = scope,
         )
     }
 }

--- a/src/main/kotlin/sigma/expressions/Reference.kt
+++ b/src/main/kotlin/sigma/expressions/Reference.kt
@@ -22,8 +22,8 @@ data class Reference(
     }
 
     override fun evaluate(
-        context: Scope,
-    ): Thunk = context.apply(referee)
+        scope: Scope,
+    ): Thunk = scope.apply(referee)
 
     override fun dump(): String = referee.dump()
 }

--- a/src/main/kotlin/sigma/expressions/Reference.kt
+++ b/src/main/kotlin/sigma/expressions/Reference.kt
@@ -1,9 +1,11 @@
 package sigma.expressions
 
+import sigma.StaticScope
 import sigma.Thunk
 import sigma.parser.antlr.SigmaParser.ReferenceContext
 import sigma.types.Type
 import sigma.values.Symbol
+import sigma.values.TypeError
 import sigma.values.tables.Scope
 
 data class Reference(
@@ -17,9 +19,13 @@ data class Reference(
         )
     }
 
-    override fun inferType(): Type {
-        TODO("Not yet implemented")
-    }
+    override fun inferType(
+        scope: StaticScope,
+    ): Type = scope.getValueType(
+        valueName = referee,
+    ) ?: throw TypeError(
+        message = "Unresolved reference: $referee"
+    )
 
     override fun evaluate(
         scope: Scope,

--- a/src/main/kotlin/sigma/expressions/SymbolLiteral.kt
+++ b/src/main/kotlin/sigma/expressions/SymbolLiteral.kt
@@ -25,7 +25,7 @@ data class SymbolLiteral(
     override fun inferType(): Type = SymbolType
 
     override fun evaluate(
-        context: Scope,
+        scope: Scope,
     ): Value = symbol
 
     override fun dump(): String = symbol.dump()

--- a/src/main/kotlin/sigma/expressions/SymbolLiteral.kt
+++ b/src/main/kotlin/sigma/expressions/SymbolLiteral.kt
@@ -1,5 +1,6 @@
 package sigma.expressions
 
+import sigma.StaticScope
 import sigma.parser.antlr.SigmaParser
 import sigma.types.SymbolType
 import sigma.types.Type
@@ -22,7 +23,7 @@ data class SymbolLiteral(
         )
     }
 
-    override fun inferType(): Type = SymbolType
+    override fun inferType(scope: StaticScope): Type = SymbolType
 
     override fun evaluate(
         scope: Scope,

--- a/src/main/kotlin/sigma/values/Closure.kt
+++ b/src/main/kotlin/sigma/values/Closure.kt
@@ -13,7 +13,7 @@ class Closure(
     override fun apply(
         argument: Value,
     ): Thunk = image.evaluate(
-        context = ArgumentTable(
+        scope = ArgumentTable(
             name = argumentName,
             value = argument,
         ).chainWith(

--- a/src/main/kotlin/sigma/values/LoopedStaticScope.kt
+++ b/src/main/kotlin/sigma/values/LoopedStaticScope.kt
@@ -1,0 +1,22 @@
+package sigma.values
+
+import sigma.StaticScope
+import sigma.StaticValueScope
+import sigma.Thunk
+import sigma.expressions.Declaration
+import sigma.expressions.Expression
+import sigma.types.Type
+import sigma.values.Symbol
+
+class LoopedStaticValueScope(
+    private val context: StaticScope,
+    private val declarations: Map<Symbol, Expression>,
+) : StaticValueScope {
+    override fun getValueType(
+        valueName: Symbol,
+    ): Type? = declarations[valueName]?.inferType(
+        scope = context.copy(valueScope = this),
+    ) ?: context.getValueType(
+        valueName = valueName,
+    )
+}

--- a/src/main/kotlin/sigma/values/tables/EmptyTable.kt
+++ b/src/main/kotlin/sigma/values/tables/EmptyTable.kt
@@ -1,9 +1,0 @@
-package sigma.values.tables
-
-import sigma.values.Value
-
-object EmptyTable : Table() {
-    override fun read(argument: Value): Value? = null
-
-    override fun dumpContent(): String? = null
-}

--- a/src/main/kotlin/sigma/values/tables/LoopedScope.kt
+++ b/src/main/kotlin/sigma/values/tables/LoopedScope.kt
@@ -11,7 +11,7 @@ class LoopedScope(
     override fun get(
         name: Symbol,
     ): Thunk? = declarations[name]?.evaluate(
-        context = this,
+        scope = this,
     ) ?: context.get(
         name = name,
     )

--- a/src/main/kotlin/sigma/values/tables/Scope.kt
+++ b/src/main/kotlin/sigma/values/tables/Scope.kt
@@ -5,12 +5,6 @@ import sigma.values.Symbol
 import sigma.values.Value
 
 abstract class Scope : Table() {
-    object Empty : Scope() {
-        override fun get(name: Symbol): Thunk? = null
-
-        override fun dumpContent(): String? = null
-    }
-
     final override fun read(argument: Value): Thunk? {
         if (argument !is Symbol) return null
 

--- a/src/test/kotlin/sigma/expressions/LetExpressionTests.kt
+++ b/src/test/kotlin/sigma/expressions/LetExpressionTests.kt
@@ -1,8 +1,8 @@
 package sigma.expressions
 
-import sigma.GlobalTypeContext
 import sigma.TypeReference
 import sigma.types.IntType
+import sigma.types.SymbolType
 import sigma.values.Symbol
 import kotlin.test.Test
 import kotlin.test.assertEquals
@@ -69,22 +69,16 @@ class LetExpressionTests {
     object TypeCheckingTests {
         @Test
         fun testSimple() {
-            val expression = Expression.parse(
+            val type = Expression.parse(
                 source = """
                     let {
-                        a: Int = b,
+                        a: Symbol = `foo`,
                     } in a
                 """.trimIndent()
-            ) as LetExpression
-
-            val declaration = expression.declarations.single()
-
-            val type = declaration.valueType!!.evaluate(
-                context = GlobalTypeContext,
-            )
+            ).obtainType()
 
             assertEquals(
-                expected = IntType,
+                expected = SymbolType,
                 actual = type,
             )
         }


### PR DESCRIPTION
- Rename `evaluate` argument to `scope`
- Nuke unused `Table` subclasses
- Introduce `StaticScope`
