### PR TITLE
types 7

### DIFF
--- a/src/main/kotlin/sigma/TypeReference.kt
+++ b/src/main/kotlin/sigma/TypeReference.kt
@@ -11,5 +11,5 @@ data class TypeReference(
         context: StaticScope,
     ): Type = context.getType(
         typeName = referee,
-    ) ?: throw TypeError("Unresolved type ${referee.dump()}")
+    ) ?: throw TypeError(message ="Unresolved type ${referee.dump()}")
 }

--- a/src/main/kotlin/sigma/expressions/Abstraction.kt
+++ b/src/main/kotlin/sigma/expressions/Abstraction.kt
@@ -10,23 +10,24 @@ import sigma.types.AbstractionType
 import sigma.types.Type
 import sigma.types.UndefinedType
 import sigma.values.FixedStaticValueScope
-import sigma.values.TypeError
 import sigma.values.tables.Scope
 
 data class Abstraction(
+    override val location: SourceLocation,
     val argumentName: Symbol,
     val argumentType: TypeExpression?,
     val image: Expression,
 ) : Expression() {
     companion object {
         fun build(
-            abstraction: AbstractionContext,
+            ctx: AbstractionContext,
         ): Abstraction = Abstraction(
-            argumentName = Symbol(abstraction.argumentName.text),
-            argumentType = abstraction.argumentType?.let {
+            location = SourceLocation.build(ctx),
+            argumentName = Symbol(ctx.argumentName.text),
+            argumentType = ctx.argumentType?.let {
                 TypeExpression.build(it)
             },
-            image = Expression.build(abstraction.image),
+            image = Expression.build(ctx.image),
         )
     }
 

--- a/src/main/kotlin/sigma/expressions/Abstraction.kt
+++ b/src/main/kotlin/sigma/expressions/Abstraction.kt
@@ -38,7 +38,7 @@ data class Abstraction(
     override fun inferType(scope: StaticScope): Type {
         val argumentType = argumentType?.evaluate(
             context = scope,
-        ) ?: return UndefinedType
+        ) ?: UndefinedType
 
         // TODO:
 //        val argumentType = argumentType?.evaluate(

--- a/src/main/kotlin/sigma/expressions/Call.kt
+++ b/src/main/kotlin/sigma/expressions/Call.kt
@@ -108,6 +108,7 @@ data class Call(
         val subjectType = subject.inferType(
             scope = scope,
         ) as? AbstractionType ?: throw TypeError(
+            location = location,
             message = "Only functions can be called",
         )
 

--- a/src/main/kotlin/sigma/expressions/Call.kt
+++ b/src/main/kotlin/sigma/expressions/Call.kt
@@ -16,14 +16,14 @@ import sigma.values.tables.Scope
 
 private var depth = 0
 
-data class Application(
+data class Call(
     val subject: Expression,
     val argument: Expression,
 ) : Expression() {
     companion object {
         fun build(
             ctx: BinaryOperationAltContext,
-        ): Application {
+        ): Call {
             val leftExpression = Expression.build(ctx.left)
             val rightExpression = Expression.build(ctx.right)
 
@@ -41,7 +41,7 @@ data class Application(
                 else -> throw UnsupportedOperationException()
             }
 
-            return Application(
+            return Call(
                 subject = Reference(
                     referee = Symbol.of(prototype.functionName),
                 ),
@@ -62,14 +62,14 @@ data class Application(
 
         fun build(
             ctx: CallExpressionAltContext,
-        ): Application = Application(
+        ): Call = Call(
             subject = Expression.build(ctx.callee),
             argument = Expression.build(ctx.argument),
         )
 
         fun build(
             ctx: CallExpressionDictAltContext,
-        ): Application = Application(
+        ): Call = Call(
             subject = Expression.build(ctx.callee),
             argument = TableConstructor.build(ctx.argument),
         )

--- a/src/main/kotlin/sigma/expressions/Expression.kt
+++ b/src/main/kotlin/sigma/expressions/Expression.kt
@@ -115,6 +115,14 @@ sealed class Expression : Term() {
 
     fun evaluateAsRoot(): Value = evaluate(scope = BuiltinScope).obtain()
 
+    fun validateAndInferType(
+        scope: StaticScope,
+    ): Type {
+        validate(scope = scope)
+
+        return inferType(scope = scope)
+    }
+
     abstract fun inferType(
         scope: StaticScope,
     ): Type

--- a/src/main/kotlin/sigma/expressions/Expression.kt
+++ b/src/main/kotlin/sigma/expressions/Expression.kt
@@ -47,7 +47,7 @@ sealed class Expression {
         ): Expression = object : SigmaParserBaseVisitor<Expression>() {
             override fun visitBinaryOperationAlt(
                 ctx: BinaryOperationAltContext,
-            ): Expression = Application.build(ctx)
+            ): Expression = Call.build(ctx)
 
             override fun visitParenExpressionAlt(
                 ctx: ParenExpressionAltContext,
@@ -83,11 +83,11 @@ sealed class Expression {
 
             override fun visitCallExpressionAlt(
                 ctx: CallExpressionAltContext,
-            ): Expression = Application.build(ctx)
+            ): Expression = Call.build(ctx)
 
             override fun visitCallExpressionDictAlt(
                 ctx: CallExpressionDictAltContext,
-            ): Expression = Application.build(ctx)
+            ): Expression = Call.build(ctx)
 
             override fun visitCallableParenAlt(
                 ctx: CallableParenAltContext,

--- a/src/main/kotlin/sigma/expressions/Expression.kt
+++ b/src/main/kotlin/sigma/expressions/Expression.kt
@@ -28,7 +28,7 @@ import sigma.types.Type
 import sigma.values.Value
 import sigma.values.tables.Scope
 
-sealed class Expression {
+sealed class Expression : Term() {
     companion object {
         fun parse(
             source: String,
@@ -121,7 +121,8 @@ sealed class Expression {
 
     open fun validate(
         scope: StaticScope,
-    ) {}
+    ) {
+    }
 
     abstract fun evaluate(
         scope: Scope,

--- a/src/main/kotlin/sigma/expressions/IntLiteral.kt
+++ b/src/main/kotlin/sigma/expressions/IntLiteral.kt
@@ -9,16 +9,19 @@ import sigma.values.Value
 import sigma.values.tables.Scope
 
 data class IntLiteral(
+    override val location: SourceLocation,
     val value: IntValue,
 ) : Expression() {
     companion object {
         fun of(value: Int) = IntLiteral(
+            location = SourceLocation.Invalid,
             value = IntValue(value = value),
         )
 
         fun build(
             ctx: IntLiteralAltContext,
         ): IntLiteral = IntLiteral(
+            location = SourceLocation.build(ctx),
             value = IntValue(value = ctx.text.toInt()),
         )
     }

--- a/src/main/kotlin/sigma/expressions/LetExpression.kt
+++ b/src/main/kotlin/sigma/expressions/LetExpression.kt
@@ -1,7 +1,6 @@
 package sigma.expressions
 
 import sigma.StaticScope
-import sigma.StaticValueScope
 import sigma.Thunk
 import sigma.values.tables.LoopedScope
 import sigma.parser.antlr.SigmaParser.LetExpressionContext
@@ -10,17 +9,19 @@ import sigma.types.Type
 import sigma.values.LoopedStaticValueScope
 
 data class LetExpression(
+    override val location: SourceLocation,
     val declarations: List<Declaration>,
     val result: Expression,
 ) : Expression() {
     companion object {
         fun build(
-            let: LetExpressionContext,
+            ctx: LetExpressionContext,
         ): LetExpression = LetExpression(
-            declarations = let.scope.declaration().map {
+            location = SourceLocation.build(ctx),
+            declarations = ctx.scope.declaration().map {
                 Declaration.build(it)
             },
-            result = Expression.build(let.result),
+            result = Expression.build(ctx.result),
         )
     }
 

--- a/src/main/kotlin/sigma/expressions/Reference.kt
+++ b/src/main/kotlin/sigma/expressions/Reference.kt
@@ -9,13 +9,15 @@ import sigma.values.TypeError
 import sigma.values.tables.Scope
 
 data class Reference(
+    override val location: SourceLocation,
     val referee: Symbol,
 ) : Expression() {
     companion object {
         fun build(
-            reference: ReferenceContext,
+            ctx: ReferenceContext,
         ): Reference = Reference(
-            referee = Symbol(name = reference.referee.text),
+            location = SourceLocation.build(ctx),
+            referee = Symbol(name = ctx.referee.text),
         )
     }
 

--- a/src/main/kotlin/sigma/expressions/SymbolLiteral.kt
+++ b/src/main/kotlin/sigma/expressions/SymbolLiteral.kt
@@ -9,16 +9,19 @@ import sigma.values.Value
 import sigma.values.tables.Scope
 
 data class SymbolLiteral(
+    override val location: SourceLocation,
     val symbol: Symbol,
 ) : Expression() {
     companion object {
         fun of(name: String) = SymbolLiteral(
+            location = SourceLocation.Invalid,
             symbol = Symbol.of(name),
         )
 
         fun build(
             ctx: SymbolLiteralAltContext,
         ): SymbolLiteral = SymbolLiteral(
+            location = SourceLocation.build(ctx),
             symbol = Symbol(
                 name = ctx.text.drop(1).dropLast(1),
             ),

--- a/src/main/kotlin/sigma/expressions/TableConstructor.kt
+++ b/src/main/kotlin/sigma/expressions/TableConstructor.kt
@@ -17,6 +17,7 @@ import sigma.values.Symbol
 import sigma.values.TypeError
 
 data class TableConstructor(
+    override val location: SourceLocation,
     val entries: List<EntryExpression>,
 ) : Expression() {
     class DuplicateKeyError(
@@ -60,7 +61,10 @@ data class TableConstructor(
         val name: Symbol,
         override val value: Expression,
     ) : EntryExpression {
-        override val key: SymbolLiteral = SymbolLiteral(symbol = name)
+        override val key: SymbolLiteral = SymbolLiteral(
+            location = SourceLocation.Invalid,
+            symbol = name,
+        )
     }
 
     data class ArbitraryEntryExpression(
@@ -75,12 +79,14 @@ data class TableConstructor(
             override fun visitDictTableAlt(
                 ctx: SigmaParser.DictTableAltContext,
             ): TableConstructor = TableConstructor(
+                location = SourceLocation.build(ctx),
                 entries = buildFromTable(ctx.table()),
             )
 
             override fun visitDictArrayAlt(
                 ctx: DictArrayAltContext,
             ): TableConstructor = TableConstructor(
+                location = SourceLocation.build(ctx),
                 entries = buildFromArray(ctx.content)
             )
         }.visit(ctx)

--- a/src/main/kotlin/sigma/expressions/Term.kt
+++ b/src/main/kotlin/sigma/expressions/Term.kt
@@ -1,0 +1,5 @@
+package sigma.expressions
+
+sealed class Term {
+    abstract val location: SourceLocation
+}

--- a/src/main/kotlin/sigma/types/AbstractionType.kt
+++ b/src/main/kotlin/sigma/types/AbstractionType.kt
@@ -13,5 +13,5 @@ data class AbstractionType(
         TODO("Not yet implemented")
     }
 
-    override fun dump(): String = "Abstraction"
+    override fun dump(): String = "${argumentType.dump()} => ${imageType.dump()}"
 }

--- a/src/main/kotlin/sigma/types/Type.kt
+++ b/src/main/kotlin/sigma/types/Type.kt
@@ -58,7 +58,7 @@ data class IntLiteralType(
         )
     }
 
-    override fun dump(): String = value.toString()
+    override fun dump(): String = "${value.value}"
 
     override val asLiteral = this
 

--- a/src/main/kotlin/sigma/values/GenericTypeError.kt
+++ b/src/main/kotlin/sigma/values/GenericTypeError.kt
@@ -1,5 +1,0 @@
-package sigma.values
-
-open class TypeError(
-    message: String,
-) : Exception(message)

--- a/src/main/kotlin/sigma/values/IntValue.kt
+++ b/src/main/kotlin/sigma/values/IntValue.kt
@@ -5,6 +5,9 @@ import sigma.BinaryOperationPrototype
 data class IntValue(
     val value: Int,
 ) : PrimitiveValue() {
+    companion object {
+        val Zero = IntValue(0)
+    }
 
     abstract class BinaryIntFunction : ComputableFunctionValue() {
         override fun apply(argument: Value): Value {

--- a/src/main/kotlin/sigma/values/TypeError.kt
+++ b/src/main/kotlin/sigma/values/TypeError.kt
@@ -1,0 +1,15 @@
+package sigma.values
+
+import sigma.expressions.SourceLocation
+
+open class TypeError(
+    location: SourceLocation? = null,
+    message: String,
+) : Exception(
+    listOfNotNull(
+        location?.toString(),
+        message,
+    ).joinToString(
+        separator = " ",
+    )
+)

--- a/src/test/kotlin/sigma/ExpressionParsingTests.kt
+++ b/src/test/kotlin/sigma/ExpressionParsingTests.kt
@@ -1,6 +1,6 @@
 package sigma
 
-import sigma.expressions.Application
+import sigma.expressions.Call
 import sigma.expressions.TableConstructor
 import sigma.expressions.Expression
 import sigma.expressions.Reference
@@ -20,11 +20,11 @@ class ExpressionParsingTests {
         }
     }
 
-    object ApplicationTests {
+    object CallTests {
         @Test
         fun testReferenceSubject() {
             assertEquals(
-                expected = Application(
+                expected = Call(
                     subject = Reference(Symbol("foo")),
                     argument = SymbolLiteral.of("bar"),
                 ),
@@ -35,7 +35,7 @@ class ExpressionParsingTests {
         @Test
         fun testDictSubject() {
             assertEquals(
-                expected = Application(
+                expected = Call(
                     subject = TableConstructor(
                         entries = listOf(
                             TableConstructor.SymbolEntryExpression(
@@ -55,7 +55,7 @@ class ExpressionParsingTests {
         @Test
         fun testDictArgumentShorthand() {
             assertEquals(
-                expected = Application(
+                expected = Call(
                     subject = Reference(Symbol.of("foo")),
                     argument = TableConstructor(
                         entries = listOf(

--- a/src/test/kotlin/sigma/ExpressionParsingTests.kt
+++ b/src/test/kotlin/sigma/ExpressionParsingTests.kt
@@ -4,6 +4,7 @@ import sigma.expressions.Call
 import sigma.expressions.TableConstructor
 import sigma.expressions.Expression
 import sigma.expressions.Reference
+import sigma.expressions.SourceLocation
 import sigma.expressions.SymbolLiteral
 import sigma.values.Symbol
 import kotlin.test.Test
@@ -14,7 +15,10 @@ class ExpressionParsingTests {
         @Test
         fun test() {
             assertEquals(
-                expected = Reference(Symbol("foo")),
+                expected = Reference(
+                    location = SourceLocation(lineIndex = 1, columnIndex = 0),
+                    referee = Symbol("foo"),
+                ),
                 actual = Expression.parse("foo"),
             )
         }
@@ -25,8 +29,15 @@ class ExpressionParsingTests {
         fun testReferenceSubject() {
             assertEquals(
                 expected = Call(
-                    subject = Reference(Symbol("foo")),
-                    argument = SymbolLiteral.of("bar"),
+                    location = SourceLocation(lineIndex = 1, columnIndex = 0),
+                    subject = Reference(
+                        location = SourceLocation(lineIndex = 1, columnIndex = 0),
+                        referee = Symbol("foo"),
+                    ),
+                    argument = SymbolLiteral(
+                        location = SourceLocation(lineIndex = 1, columnIndex = 4),
+                        symbol = Symbol.of("bar"),
+                    ),
                 ),
                 actual = Expression.parse("foo[`bar`]"),
             )
@@ -36,15 +47,23 @@ class ExpressionParsingTests {
         fun testDictSubject() {
             assertEquals(
                 expected = Call(
+                    location = SourceLocation(lineIndex = 1, columnIndex = 0),
                     subject = TableConstructor(
+                        location = SourceLocation(lineIndex = 1, columnIndex = 0),
                         entries = listOf(
                             TableConstructor.SymbolEntryExpression(
                                 name = Symbol.of("foo"),
-                                value = SymbolLiteral.of("bar"),
+                                value = SymbolLiteral(
+                                    location = SourceLocation(lineIndex = 1, columnIndex = 7),
+                                    symbol = Symbol.of("bar"),
+                                ),
                             ),
                         ),
                     ),
-                    argument = SymbolLiteral.of("foo"),
+                    argument = SymbolLiteral(
+                        location = SourceLocation(lineIndex = 1, columnIndex = 14),
+                        symbol = Symbol.of("foo"),
+                    ),
                 ),
                 actual = Expression.parse(
                     source = "{foo = `bar`}[`foo`]",
@@ -56,12 +75,20 @@ class ExpressionParsingTests {
         fun testDictArgumentShorthand() {
             assertEquals(
                 expected = Call(
-                    subject = Reference(Symbol.of("foo")),
+                    location = SourceLocation(lineIndex = 1, columnIndex = 0),
+                    subject = Reference(
+                        location = SourceLocation(lineIndex = 1, columnIndex = 0),
+                        referee = Symbol.of("foo")
+                    ),
                     argument = TableConstructor(
+                        location = SourceLocation(lineIndex = 1, columnIndex = 3),
                         entries = listOf(
                             TableConstructor.SymbolEntryExpression(
                                 name = Symbol.of("bar"),
-                                value = SymbolLiteral.of("baz"),
+                                value = SymbolLiteral(
+                                    location = SourceLocation(lineIndex = 1, columnIndex = 10),
+                                    symbol = Symbol.of("baz"),
+                                ),
                             ),
                         ),
                     ),

--- a/src/test/kotlin/sigma/TableConstructorTests.kt
+++ b/src/test/kotlin/sigma/TableConstructorTests.kt
@@ -6,6 +6,7 @@ import sigma.expressions.TableConstructor
 import sigma.expressions.Expression
 import sigma.expressions.IntLiteral
 import sigma.expressions.Reference
+import sigma.expressions.SourceLocation
 import sigma.expressions.TableConstructor.DuplicateKeyError
 import sigma.expressions.TableConstructor.InconsistentValuesError
 import sigma.expressions.TableConstructor.InconsistentKeysError
@@ -30,14 +31,21 @@ object TableConstructorTests {
         fun testSimple() {
             assertEquals(
                 expected = TableConstructor(
+                    location = SourceLocation(lineIndex = 1, columnIndex = 0),
                     entries = listOf(
                         TableConstructor.SymbolEntryExpression(
                             name = Symbol.of("foo"),
-                            value = Reference(Symbol.of("baz1")),
+                            value = Reference(
+                                location = SourceLocation(lineIndex = 1, columnIndex = 7),
+                                referee = Symbol.of("baz1"),
+                            ),
                         ),
                         TableConstructor.SymbolEntryExpression(
                             name = Symbol.of("bar"),
-                            value = Reference(Symbol.of("baz2")),
+                            value = Reference(
+                                location = SourceLocation(lineIndex = 1, columnIndex = 19),
+                                referee = Symbol.of("baz2"),
+                            ),
                         ),
                     ),
                 ),
@@ -49,14 +57,24 @@ object TableConstructorTests {
         fun testWithArbitrary() {
             assertEquals(
                 expected = TableConstructor(
+                    location = SourceLocation(lineIndex = 1, columnIndex = 0),
                     entries = listOf(
                         TableConstructor.SymbolEntryExpression(
                             name = Symbol.of("foo"),
-                            value = Reference(Symbol.of("baz1")),
+                            value = Reference(
+                                location = SourceLocation(lineIndex = 1, columnIndex = 7),
+                                referee = Symbol.of("baz1"),
+                            ),
                         ),
                         TableConstructor.ArbitraryEntryExpression(
-                            key = Reference(Symbol.of("baz")),
-                            value = Reference(Symbol.of("baz2")),
+                            key = Reference(
+                                location = SourceLocation(lineIndex = 1, columnIndex = 14),
+                                referee = Symbol.of("baz"),
+                            ),
+                            value = Reference(
+                                location = SourceLocation(lineIndex = 1, columnIndex = 21),
+                                referee = Symbol.of("baz2"),
+                            ),
                         ),
                     ),
                 ),
@@ -68,18 +86,28 @@ object TableConstructorTests {
         fun testArray() {
             assertEquals(
                 expected = TableConstructor(
+                    location = SourceLocation(lineIndex = 1, columnIndex = 0),
                     entries = listOf(
                         TableConstructor.ArbitraryEntryExpression(
                             key = IntLiteral.of(0),
-                            value = Reference(Symbol.of("foo")),
+                            value = Reference(
+                                location = SourceLocation(lineIndex = 1, columnIndex = 1),
+                                referee = Symbol.of("foo"),
+                            ),
                         ),
                         TableConstructor.ArbitraryEntryExpression(
                             key = IntLiteral.of(1),
-                            value = Reference(Symbol.of("bar")),
+                            value = Reference(
+                                location = SourceLocation(lineIndex = 1, columnIndex = 6),
+                                referee = Symbol.of("bar"),
+                            ),
                         ),
                         TableConstructor.ArbitraryEntryExpression(
                             key = IntLiteral.of(2),
-                            value = Reference(Symbol.of("baz")),
+                            value = Reference(
+                                location = SourceLocation(lineIndex = 1, columnIndex = 11),
+                                referee = Symbol.of("baz"),
+                            ),
                         ),
                     ),
                 ),

--- a/src/test/kotlin/sigma/expressions/AbstractionTests.kt
+++ b/src/test/kotlin/sigma/expressions/AbstractionTests.kt
@@ -1,10 +1,11 @@
 package sigma.expressions
 
 import sigma.GlobalStaticScope
-import sigma.TypeExpression
 import sigma.TypeReference
 import sigma.types.AbstractionType
 import sigma.types.IntCollectiveType
+import sigma.types.IntLiteralType
+import sigma.types.UndefinedType
 import sigma.values.IntValue
 import sigma.values.Symbol
 import kotlin.test.Test
@@ -43,6 +44,21 @@ class AbstractionTests {
                 ),
                 actual = Expression.parse(
                     source = "[n: Int] => n",
+                ).inferType(
+                    scope = GlobalStaticScope,
+                ),
+            )
+        }
+
+        @Test
+        fun testUnannotatedArgument() {
+            assertEquals(
+                expected = AbstractionType(
+                    argumentType = UndefinedType,
+                    imageType = IntLiteralType(IntValue.Zero),
+                ),
+                actual = Expression.parse(
+                    source = "[a] => 0",
                 ).inferType(
                     scope = GlobalStaticScope,
                 ),

--- a/src/test/kotlin/sigma/expressions/AbstractionTests.kt
+++ b/src/test/kotlin/sigma/expressions/AbstractionTests.kt
@@ -5,6 +5,7 @@ import sigma.TypeExpression
 import sigma.TypeReference
 import sigma.types.AbstractionType
 import sigma.types.IntCollectiveType
+import sigma.values.IntValue
 import sigma.values.Symbol
 import kotlin.test.Test
 import kotlin.test.assertEquals
@@ -15,11 +16,15 @@ class AbstractionTests {
         fun test() {
             assertEquals(
                 expected = Abstraction(
+                    location = SourceLocation(lineIndex = 1, columnIndex = 0),
                     argumentName = Symbol.of("n"),
                     argumentType = TypeReference(
                         referee = Symbol.of("Int"),
                     ),
-                    image = IntLiteral.of(0),
+                    image = IntLiteral(
+                        SourceLocation(lineIndex = 1, columnIndex = 12),
+                        value = IntValue(0),
+                    ),
                 ),
                 actual = Expression.parse(
                     source = "[n: Int] => 0",
@@ -45,6 +50,5 @@ class AbstractionTests {
         }
     }
 
-    object EvaluationTests {
-    }
+    object EvaluationTests {}
 }

--- a/src/test/kotlin/sigma/expressions/CallTests.kt
+++ b/src/test/kotlin/sigma/expressions/CallTests.kt
@@ -5,7 +5,7 @@ import sigma.values.Symbol
 import kotlin.test.Test
 import kotlin.test.assertEquals
 
-class ApplicationTests {
+class CallTests {
     object EvaluationTests {
         @Test
         fun testDictSubject() {

--- a/src/test/kotlin/sigma/expressions/IntLiteralTests.kt
+++ b/src/test/kotlin/sigma/expressions/IntLiteralTests.kt
@@ -9,7 +9,10 @@ class IntLiteralTests {
         @Test
         fun test() {
             assertEquals(
-                expected = IntLiteral.of(123),
+                expected = IntLiteral(
+                    location = SourceLocation(lineIndex = 1, columnIndex = 0),
+                    IntValue(123),
+                ),
                 actual = Expression.parse(
                     source = "123",
                 ),

--- a/src/test/kotlin/sigma/expressions/LetExpressionTests.kt
+++ b/src/test/kotlin/sigma/expressions/LetExpressionTests.kt
@@ -103,7 +103,26 @@ class LetExpressionTests {
                         b = a,
                     } in b
                 """.trimIndent()
-            ).inferType(
+            ).validateAndInferType(
+                scope = GlobalStaticScope,
+            )
+
+            assertEquals(
+                expected = BoolType,
+                actual = type,
+            )
+        }
+
+        @Test
+        fun testInferredFunctionType() {
+            val type = Expression.parse(
+                source = """
+                    let {
+                        f = [n: Int] => false,
+                        a = f[0],
+                    } in a
+                """.trimIndent()
+            ).validateAndInferType(
                 scope = GlobalStaticScope,
             )
 

--- a/src/test/kotlin/sigma/expressions/LetExpressionTests.kt
+++ b/src/test/kotlin/sigma/expressions/LetExpressionTests.kt
@@ -5,9 +5,7 @@ import sigma.GlobalStaticScope
 import sigma.TypeReference
 import sigma.types.BoolType
 import sigma.types.IntCollectiveType
-import sigma.types.SymbolType
 import sigma.values.Symbol
-import kotlin.math.exp
 import kotlin.test.Test
 import kotlin.test.assertEquals
 
@@ -20,7 +18,7 @@ class LetExpressionTests {
                     declarations = listOf(
                         Declaration(
                             name = Symbol.of("g"),
-                            value = Application(
+                            value = Call(
                                 subject = Reference(Symbol.of("h")),
                                 argument = Reference(Symbol.of("a")),
                             ),
@@ -30,7 +28,7 @@ class LetExpressionTests {
                             value = Reference(Symbol.of("g")),
                         ),
                     ),
-                    result = Application(
+                    result = Call(
                         subject = Reference(Symbol.of("f")),
                         argument = Reference(Symbol.of("x")),
                     ),

--- a/src/test/kotlin/sigma/expressions/LetExpressionTests.kt
+++ b/src/test/kotlin/sigma/expressions/LetExpressionTests.kt
@@ -15,22 +15,40 @@ class LetExpressionTests {
         fun testSimple() {
             assertEquals(
                 expected = LetExpression(
+                    location = SourceLocation(lineIndex = 1, columnIndex = 0),
                     declarations = listOf(
                         Declaration(
                             name = Symbol.of("g"),
                             value = Call(
-                                subject = Reference(Symbol.of("h")),
-                                argument = Reference(Symbol.of("a")),
+                                location = SourceLocation(lineIndex = 2, columnIndex = 8),
+                                subject = Reference(
+                                    location = SourceLocation(lineIndex = 2, columnIndex = 8),
+                                    referee = Symbol.of("h"),
+                                ),
+                                argument = Reference(
+                                    location = SourceLocation(lineIndex = 2, columnIndex = 10),
+                                    referee = Symbol.of("a"),
+                                ),
                             ),
                         ),
                         Declaration(
                             name = Symbol.of("f"),
-                            value = Reference(Symbol.of("g")),
+                            value = Reference(
+                                location = SourceLocation(lineIndex = 3, columnIndex = 8),
+                                referee = Symbol.of("g"),
+                            ),
                         ),
                     ),
                     result = Call(
-                        subject = Reference(Symbol.of("f")),
-                        argument = Reference(Symbol.of("x")),
+                        location = SourceLocation(lineIndex = 4, columnIndex = 5),
+                        subject = Reference(
+                            location = SourceLocation(lineIndex = 4, columnIndex = 5),
+                            referee = Symbol.of("f"),
+                        ),
+                        argument = Reference(
+                            location = SourceLocation(lineIndex = 4, columnIndex = 7),
+                            referee = Symbol.of("x"),
+                        ),
                     ),
                 ),
                 actual = Expression.parse(
@@ -48,16 +66,23 @@ class LetExpressionTests {
         fun testWithTypeAnnotation() {
             assertEquals(
                 expected = LetExpression(
+                    location = SourceLocation(lineIndex = 1, columnIndex = 0),
                     declarations = listOf(
                         Declaration(
                             name = Symbol.of("a"),
                             valueType = TypeReference(
-                                referee = Symbol.of("Int"),
+                                Symbol.of("Int"),
                             ),
-                            value = Reference(Symbol.of("b")),
+                            value = Reference(
+                                location = SourceLocation(lineIndex = 1, columnIndex = 15),
+                                referee = Symbol.of("b"),
+                            ),
                         ),
                     ),
-                    result = Reference(Symbol.of("a")),
+                    result = Reference(
+                        location = SourceLocation(lineIndex = 1, columnIndex = 22),
+                        referee = Symbol.of("a"),
+                    ),
                 ),
                 actual = Expression.parse(
                     source = """

--- a/src/test/kotlin/sigma/expressions/SymbolLiteralTests.kt
+++ b/src/test/kotlin/sigma/expressions/SymbolLiteralTests.kt
@@ -1,5 +1,6 @@
 package sigma.expressions
 
+import sigma.values.Symbol
 import kotlin.test.Test
 import kotlin.test.assertEquals
 
@@ -8,9 +9,12 @@ class SymbolLiteralTests {
         @Test
         fun test() {
             assertEquals(
-                expected = SymbolLiteral.of("foo"),
+                expected = SymbolLiteral(
+                    location = SourceLocation(lineIndex = 1, columnIndex = 0),
+                    symbol = Symbol.of("foo"),
+                ),
                 actual = Expression.parse(
-                    source = "`foo``",
+                    source = "`foo`",
                 ),
             )
         }

--- a/src/test/kotlin/sigma/programs/euler/EulerProblemsTests.kt
+++ b/src/test/kotlin/sigma/programs/euler/EulerProblemsTests.kt
@@ -23,8 +23,6 @@ class EulerProblemsTests {
     }
 
     @Test
-    // TODO: Re-enable
-    @Disabled
     fun testProblem7() {
         // For 20th prime (for performance reasons)
         assertEquals(


### PR DESCRIPTION
- Rename "application" to "call"
- Add source location info to nodes
- Add location info to type errors
- Improve handling of unannotated arguments
- Re-enable `testProblem7`
