### PR TITLE
generics 1

### DIFF
--- a/src/main/antlr/SigmaLexer.g4
+++ b/src/main/antlr/SigmaLexer.g4
@@ -9,6 +9,8 @@ LeftBrace : '{' ;
 RightBrace : '}' ;
 LeftBracket : '[' ;
 RightBracket : ']' ;
+Lt : '<' ;
+Gt : '>' ;
 
 Lte : '<=' ;
 Gte : '>=' ;
@@ -22,8 +24,7 @@ Asterisk : '*' ;
 Slash : '/' ;
 Plus : '+' ;
 Minus : '-' ;
-Lt : '<' ;
-Gt : '>' ;
+Bang : '!' ;
 
 Arrow : '=>' ;
 Identifier : [a-zA-Z] [a-zA-Z0-9]* ;

--- a/src/main/antlr/SigmaParser.g4
+++ b/src/main/antlr/SigmaParser.g4
@@ -44,7 +44,14 @@ reference
     ;
 
 abstraction
-    : LeftBracket argumentName=identifier (Colon argumentType=typeExpression)? RightBracket Arrow image=expression ;
+    :   (Bang metaArgument)?
+        LeftBracket argumentName=identifier (Colon argumentType=typeExpression)? RightBracket
+        Arrow image=expression
+    ;
+
+metaArgument
+    : LeftBracket name=identifier RightBracket
+    ;
 
 identifier
     : Identifier ;

--- a/src/main/kotlin/sigma/Thunk.kt
+++ b/src/main/kotlin/sigma/Thunk.kt
@@ -11,7 +11,7 @@ abstract class Thunk {
         throw UnsupportedOperationException()
     }
 
-    override fun toString(): String = "Thunk"
+    override fun toString(): String = dump()
 
     abstract val toEvaluatedValue: Value
 

--- a/src/main/kotlin/sigma/Thunk.kt
+++ b/src/main/kotlin/sigma/Thunk.kt
@@ -13,7 +13,7 @@ abstract class Thunk {
 
     override fun toString(): String = "Thunk"
 
-    abstract fun obtain(): Value
+    abstract val toEvaluatedValue: Value
 
     abstract fun dump(): String
 }

--- a/src/main/kotlin/sigma/TypeExpression.kt
+++ b/src/main/kotlin/sigma/TypeExpression.kt
@@ -1,10 +1,11 @@
 package sigma
 
+import sigma.expressions.Term
 import sigma.parser.antlr.SigmaParser.TypeExpressionContext
 import sigma.types.Type
 import sigma.values.Symbol
 
-interface TypeExpression {
+abstract class TypeExpression : Term() {
     companion object {
         fun build(
             ctx: TypeExpressionContext,
@@ -13,7 +14,7 @@ interface TypeExpression {
         )
     }
 
-    fun evaluate(
+    abstract fun evaluate(
         context: StaticScope,
     ): Type
 }

--- a/src/main/kotlin/sigma/TypeReference.kt
+++ b/src/main/kotlin/sigma/TypeReference.kt
@@ -1,15 +1,18 @@
 package sigma
 
+import sigma.expressions.SourceLocation
 import sigma.types.Type
 import sigma.values.Symbol
 import sigma.values.TypeError
 
 data class TypeReference(
+    // TODO
+    override val location: SourceLocation = SourceLocation.Invalid,
     val referee: Symbol,
-) : TypeExpression {
+) : TypeExpression() {
     override fun evaluate(
         context: StaticScope,
     ): Type = context.getType(
         typeName = referee,
-    ) ?: throw TypeError(message ="Unresolved type ${referee.dump()}")
+    ) ?: throw TypeError(message = "Unresolved type ${referee.dump()}")
 }

--- a/src/main/kotlin/sigma/TypeReference.kt
+++ b/src/main/kotlin/sigma/TypeReference.kt
@@ -11,5 +11,5 @@ data class TypeReference(
         context: StaticScope,
     ): Type = context.getType(
         typeName = referee,
-    ) ?: throw TypeError("Unresolved type ${referee.dump()}")
+    ) ?: throw TypeError(message ="Unresolved type ${referee.dump()}")
 }

--- a/src/main/kotlin/sigma/expressions/Abstraction.kt
+++ b/src/main/kotlin/sigma/expressions/Abstraction.kt
@@ -6,6 +6,7 @@ import sigma.values.Closure
 import sigma.values.Symbol
 import sigma.values.Value
 import sigma.parser.antlr.SigmaParser.AbstractionContext
+import sigma.parser.antlr.SigmaParser.MetaArgumentContext
 import sigma.types.AbstractionType
 import sigma.types.Type
 import sigma.types.UndefinedType
@@ -14,15 +15,33 @@ import sigma.values.tables.Scope
 
 data class Abstraction(
     override val location: SourceLocation,
+    val metaArgument: MetaArgumentExpression? = null,
     val argumentName: Symbol,
     val argumentType: TypeExpression?,
     val image: Expression,
 ) : Expression() {
+    data class MetaArgumentExpression(
+        override val location: SourceLocation,
+        val name: Symbol,
+    ) : Term() {
+        companion object {
+            fun build(
+                ctx: MetaArgumentContext,
+            ): MetaArgumentExpression = MetaArgumentExpression(
+                location = SourceLocation.build(ctx),
+                name = Symbol.of(ctx.name.text),
+            )
+        }
+    }
+
     companion object {
         fun build(
             ctx: AbstractionContext,
         ): Abstraction = Abstraction(
             location = SourceLocation.build(ctx),
+            metaArgument = ctx.metaArgument()?.let {
+                MetaArgumentExpression.build(it)
+            },
             argumentName = Symbol(ctx.argumentName.text),
             argumentType = ctx.argumentType?.let {
                 TypeExpression.build(it)

--- a/src/main/kotlin/sigma/expressions/Abstraction.kt
+++ b/src/main/kotlin/sigma/expressions/Abstraction.kt
@@ -38,7 +38,7 @@ data class Abstraction(
     override fun inferType(scope: StaticScope): Type {
         val argumentType = argumentType?.evaluate(
             context = scope,
-        ) ?: return UndefinedType
+        ) ?: UndefinedType
 
         // TODO:
 //        val argumentType = argumentType?.evaluate(

--- a/src/main/kotlin/sigma/expressions/Call.kt
+++ b/src/main/kotlin/sigma/expressions/Call.kt
@@ -118,7 +118,7 @@ data class Call(
     override fun evaluate(
         scope: Scope,
     ): Thunk {
-        val subjectValue = subject.evaluate(scope = scope).obtain()
+        val subjectValue = subject.evaluate(scope = scope).toEvaluatedValue
 
         if (subjectValue !is FunctionValue) throw IllegalStateException("Subject $subjectValue is not a function")
 
@@ -126,7 +126,7 @@ data class Call(
 
         // Thought: Obtaining argument here might not be lazy enough
         val image = subjectValue.apply(
-            argument = argumentValue.obtain(),
+            argument = argumentValue.toEvaluatedValue,
         )
 
         return image

--- a/src/main/kotlin/sigma/expressions/Call.kt
+++ b/src/main/kotlin/sigma/expressions/Call.kt
@@ -108,6 +108,7 @@ data class Call(
         val subjectType = subject.inferType(
             scope = scope,
         ) as? AbstractionType ?: throw TypeError(
+            location = location,
             message = "Only functions can be called",
         )
 

--- a/src/main/kotlin/sigma/expressions/Expression.kt
+++ b/src/main/kotlin/sigma/expressions/Expression.kt
@@ -103,14 +103,17 @@ sealed class Expression : Term() {
         }.visit(expression) ?: throw IllegalArgumentException("Can't match expression ${expression::class}")
     }
 
-    fun bind(scope: Scope): Thunk = object : Thunk() {
-        override val toEvaluatedValue: Value
-            get() = this@Expression.evaluate(
+    inner class BoundThunk(private val scope: Scope) : Thunk() {
+        override val toEvaluatedValue: Value by lazy {
+            this@Expression.evaluate(
                 scope = scope,
             ).toEvaluatedValue
+        }
 
         override fun dump(): String = "(bound thunk)"
     }
+
+    fun bind(scope: Scope): Thunk = BoundThunk(scope = scope)
 
     fun inferTypeAsRoot() = inferType(scope = GlobalStaticScope)
 

--- a/src/main/kotlin/sigma/expressions/Expression.kt
+++ b/src/main/kotlin/sigma/expressions/Expression.kt
@@ -115,6 +115,14 @@ sealed class Expression : Term() {
 
     fun evaluateAsRoot(): Value = evaluate(scope = BuiltinScope).obtain()
 
+    fun validateAndInferType(
+        scope: StaticScope,
+    ): Type {
+        validate(scope = scope)
+
+        return inferType(scope = scope)
+    }
+
     abstract fun inferType(
         scope: StaticScope,
     ): Type

--- a/src/main/kotlin/sigma/expressions/Expression.kt
+++ b/src/main/kotlin/sigma/expressions/Expression.kt
@@ -104,16 +104,17 @@ sealed class Expression : Term() {
     }
 
     fun bind(scope: Scope): Thunk = object : Thunk() {
-        override fun obtain(): Value = this@Expression.evaluate(
-            scope = scope,
-        ).obtain()
+        override val toEvaluatedValue: Value
+            get() = this@Expression.evaluate(
+                scope = scope,
+            ).toEvaluatedValue
 
         override fun dump(): String = "(bound thunk)"
     }
 
     fun inferTypeAsRoot() = inferType(scope = GlobalStaticScope)
 
-    fun evaluateAsRoot(): Value = evaluate(scope = BuiltinScope).obtain()
+    fun evaluateAsRoot(): Value = evaluate(scope = BuiltinScope).toEvaluatedValue
 
     fun validateAndInferType(
         scope: StaticScope,

--- a/src/main/kotlin/sigma/expressions/TableConstructor.kt
+++ b/src/main/kotlin/sigma/expressions/TableConstructor.kt
@@ -181,7 +181,7 @@ data class TableConstructor(
         scope: Scope,
     ): DictTable = DictTable(
         associations = entries.associate {
-            val key = it.key.evaluate(scope = scope).obtain() as PrimitiveValue
+            val key = it.key.evaluate(scope = scope).toEvaluatedValue as PrimitiveValue
             val value = it.value.bind(scope = scope)
 
             key to value

--- a/src/main/kotlin/sigma/expressions/Term.kt
+++ b/src/main/kotlin/sigma/expressions/Term.kt
@@ -1,5 +1,5 @@
 package sigma.expressions
 
-sealed class Term {
+abstract class Term {
     abstract val location: SourceLocation
 }

--- a/src/main/kotlin/sigma/types/AbstractionType.kt
+++ b/src/main/kotlin/sigma/types/AbstractionType.kt
@@ -1,11 +1,13 @@
 package sigma.types
 
 sealed class FunctionType : Type() {
+    abstract val metaArgumentType: TableType
     abstract val argumentType: Type
     abstract val imageType: Type
 }
 
 data class AbstractionType(
+    override val metaArgumentType: TableType = TableType.Empty,
     override val argumentType: Type,
     override val imageType: Type,
 ) : FunctionType() {
@@ -13,5 +15,14 @@ data class AbstractionType(
         TODO("Not yet implemented")
     }
 
-    override fun dump(): String = "${argumentType.dump()} => ${imageType.dump()}"
+    override fun dump(): String {
+        val metaArgument = if (!metaArgumentType.isDefinitevlyEmpty()) "!${metaArgumentType.dump()}" else null
+
+        return listOfNotNull(
+            metaArgument,
+            "${argumentType.dump()} => ${imageType.dump()}",
+        ).joinToString(
+            separator = " ",
+        )
+    }
 }

--- a/src/main/kotlin/sigma/types/AbstractionType.kt
+++ b/src/main/kotlin/sigma/types/AbstractionType.kt
@@ -13,5 +13,5 @@ data class AbstractionType(
         TODO("Not yet implemented")
     }
 
-    override fun dump(): String = "Abstraction"
+    override fun dump(): String = "${argumentType.dump()} => ${imageType.dump()}"
 }

--- a/src/main/kotlin/sigma/types/TableType.kt
+++ b/src/main/kotlin/sigma/types/TableType.kt
@@ -61,3 +61,11 @@ data class DictType(
 //) : DictType() {
 //    override val keyType: PrimitiveType = IntCollectiveType
 //}
+
+@Suppress("FunctionName")
+fun ArrayType(
+    elementType: Type,
+) = DictType(
+    keyType = IntCollectiveType,
+    valueType = elementType,
+)

--- a/src/main/kotlin/sigma/types/TableType.kt
+++ b/src/main/kotlin/sigma/types/TableType.kt
@@ -1,12 +1,26 @@
 package sigma.types
 
 sealed class TableType : FunctionType() {
-    override fun dump(): String = "Table"
+    object Empty : TableType() {
+        override val keyType: PrimitiveType = NeverType
 
-    override val argumentType: Type
+        override val valueType: Type = NeverType
+
+        override fun isDefinitevlyEmpty(): Boolean = true
+
+        override fun isAssignableTo(otherType: Type): Boolean {
+            TODO("Not yet implemented")
+        }
+
+        override fun dump(): String = "{}"
+    }
+
+    final override val metaArgumentType: TableType = Empty
+
+    final override val argumentType: Type
         get() = keyType
 
-    override val imageType: Type
+    final override val imageType: Type
         get() = TODO("valueType | UndefinedType")
 
     abstract val keyType: PrimitiveType
@@ -15,6 +29,8 @@ sealed class TableType : FunctionType() {
      * Any type but [UndefinedType]
      */
     abstract val valueType: Type
+
+    abstract fun isDefinitevlyEmpty(): Boolean
 }
 
 // TODO: Simplify this, at least for now. Add union types and iterate
@@ -31,11 +47,23 @@ data class StructType(
         TODO("Not yet implemented")
     }
 
+    override fun dump(): String {
+        val dumpedEntries = entries.map { (entryKeyLiteralType, valueType) ->
+            val entryKeyType = entryKeyLiteralType.asType
+
+            "(${entryKeyType.dump()}): ${valueType.dump()}"
+        }
+
+        return "{${dumpedEntries.joinToString()}}"
+    }
+
     override val keyType: PrimitiveType
         get() = TODO("key1 | key2 | ...")
 
     override val valueType: Type
         get() = TODO("value1 | value2 | ...")
+
+    override fun isDefinitevlyEmpty(): Boolean = entries.isEmpty()
 }
 
 // Type of tables with keys of a specific primitive type and values of a
@@ -50,6 +78,10 @@ data class DictType(
     override fun isAssignableTo(otherType: Type): Boolean {
         TODO("Not yet implemented")
     }
+
+    override fun dump(): String = "{${keyType.dump()} ~> ${valueType.dump()}}"
+
+    override fun isDefinitevlyEmpty(): Boolean = false
 }
 
 //// Type of tables with keys { 0, 1, 2, ..., n } of type Int and values of a

--- a/src/main/kotlin/sigma/types/Type.kt
+++ b/src/main/kotlin/sigma/types/Type.kt
@@ -58,7 +58,7 @@ data class IntLiteralType(
         )
     }
 
-    override fun dump(): String = value.toString()
+    override fun dump(): String = "${value.value}"
 
     override val asLiteral = this
 

--- a/src/main/kotlin/sigma/types/Type.kt
+++ b/src/main/kotlin/sigma/types/Type.kt
@@ -15,7 +15,17 @@ sealed class Type {
     abstract fun dump(): String
 }
 
+object MetaType : Type() {
+    override fun isAssignableTo(otherType: Type): Boolean {
+        TODO("Not yet implemented")
+    }
+
+    override fun dump(): String = "Type"
+}
+
 sealed interface LiteralType {
+    val asType: PrimitiveType
+
     val value: PrimitiveValue
 }
 
@@ -28,6 +38,12 @@ object UndefinedType : Type() {
 }
 
 sealed class PrimitiveType : Type()
+
+object NeverType : PrimitiveType() {
+    override fun isAssignableTo(otherType: Type): Boolean = true
+
+    override fun dump(): String = "Never"
+}
 
 object BoolType : PrimitiveType() {
     override fun isAssignableTo(
@@ -65,6 +81,8 @@ data class IntLiteralType(
     override fun isAssignableTo(
         otherType: Type,
     ): Boolean = otherType == this || otherType is IntCollectiveType
+
+    override val asType: PrimitiveType = this
 }
 
 data class SymbolType(
@@ -85,4 +103,6 @@ data class SymbolType(
     override fun isAssignableTo(
         otherType: Type,
     ): Boolean = this == otherType
+
+    override val asType: PrimitiveType = this
 }

--- a/src/main/kotlin/sigma/values/ComputableFunctionValue.kt
+++ b/src/main/kotlin/sigma/values/ComputableFunctionValue.kt
@@ -1,4 +1,6 @@
 package sigma.values
 
 // Thought: Is this needed anymore?
-abstract class ComputableFunctionValue : FunctionValue()
+abstract class ComputableFunctionValue : FunctionValue() {
+    override fun dump(): String = "(computable function)"
+}

--- a/src/main/kotlin/sigma/values/FunctionValue.kt
+++ b/src/main/kotlin/sigma/values/FunctionValue.kt
@@ -11,11 +11,11 @@ abstract class FunctionValue : Value() {
 
             val primary = argument.apply(
                 argument = Symbol.of("primary"),
-            ).obtain() as FunctionValue
+            ).toEvaluatedValue as FunctionValue
 
             val secondary = argument.apply(
                 argument = Symbol.of("secondary"),
-            ).obtain() as FunctionValue
+            ).toEvaluatedValue as FunctionValue
 
             return object : FunctionValue() {
                 override fun apply(argument: Value): Thunk {

--- a/src/main/kotlin/sigma/values/GenericTypeError.kt
+++ b/src/main/kotlin/sigma/values/GenericTypeError.kt
@@ -1,5 +1,0 @@
-package sigma.values
-
-open class TypeError(
-    message: String,
-) : Exception(message)

--- a/src/main/kotlin/sigma/values/IntValue.kt
+++ b/src/main/kotlin/sigma/values/IntValue.kt
@@ -5,6 +5,9 @@ import sigma.BinaryOperationPrototype
 data class IntValue(
     val value: Int,
 ) : PrimitiveValue() {
+    companion object {
+        val Zero = IntValue(0)
+    }
 
     abstract class BinaryIntFunction : ComputableFunctionValue() {
         override fun apply(argument: Value): Value {

--- a/src/main/kotlin/sigma/values/IntValue.kt
+++ b/src/main/kotlin/sigma/values/IntValue.kt
@@ -13,8 +13,8 @@ data class IntValue(
         override fun apply(argument: Value): Value {
             argument as FunctionValue
 
-            val left = argument.apply(Symbol.of(prototype.leftArgumentName)).obtain()
-            val right = argument.apply(Symbol.of(prototype.rightArgumentName)).obtain()
+            val left = argument.apply(Symbol.of(prototype.leftArgumentName)).toEvaluatedValue
+            val right = argument.apply(Symbol.of(prototype.rightArgumentName)).toEvaluatedValue
 
             left as IntValue
             right as IntValue

--- a/src/main/kotlin/sigma/values/TypeError.kt
+++ b/src/main/kotlin/sigma/values/TypeError.kt
@@ -1,0 +1,15 @@
+package sigma.values
+
+import sigma.expressions.SourceLocation
+
+open class TypeError(
+    location: SourceLocation? = null,
+    message: String,
+) : Exception(
+    listOfNotNull(
+        location?.toString(),
+        message,
+    ).joinToString(
+        separator = " ",
+    )
+)

--- a/src/main/kotlin/sigma/values/Value.kt
+++ b/src/main/kotlin/sigma/values/Value.kt
@@ -3,5 +3,6 @@ package sigma.values
 import sigma.Thunk
 
 sealed class Value : Thunk() {
-    final override fun obtain(): Value = this
+    final override val toEvaluatedValue: Value
+        get() = this
 }

--- a/src/main/kotlin/sigma/values/tables/DictTable.kt
+++ b/src/main/kotlin/sigma/values/tables/DictTable.kt
@@ -1,7 +1,6 @@
 package sigma.values.tables
 
 import sigma.Thunk
-import sigma.expressions.Expression
 import sigma.values.PrimitiveValue
 import sigma.values.Symbol
 import sigma.values.Value
@@ -15,14 +14,14 @@ class DictTable(
 
     override fun dumpContent(): String? {
         val entries = associations.mapValues { (_, image) ->
-            image.obtain()
+            image.toEvaluatedValue
         }.entries
 
         if (entries.isEmpty()) return null
 
         return entries.joinToString(separator = ", ") {
             val keyStr = dumpKey(key = it.key)
-            val imageStr = it.value.obtain().dump()
+            val imageStr = it.value.toEvaluatedValue.dump()
 
             "$keyStr = $imageStr"
         }

--- a/src/main/kotlin/sigma/values/tables/DictTable.kt
+++ b/src/main/kotlin/sigma/values/tables/DictTable.kt
@@ -8,6 +8,12 @@ import sigma.values.Value
 class DictTable(
     private val associations: Map<PrimitiveValue, Thunk>,
 ) : Table() {
+    companion object {
+        val Empty = DictTable(
+            associations = emptyMap(),
+        )
+    }
+
     override fun read(
         argument: Value,
     ): Thunk? = associations[argument]

--- a/src/test/kotlin/sigma/expressions/AbstractionTests.kt
+++ b/src/test/kotlin/sigma/expressions/AbstractionTests.kt
@@ -4,11 +4,15 @@ import sigma.GlobalStaticScope
 import sigma.TypeReference
 import sigma.expressions.Abstraction.MetaArgumentExpression
 import sigma.types.AbstractionType
+import sigma.types.ArrayType
+import sigma.types.BoolType
 import sigma.types.IntCollectiveType
 import sigma.types.IntLiteralType
+import sigma.types.MetaType
 import sigma.types.UndefinedType
 import sigma.values.IntValue
 import sigma.values.Symbol
+import sigma.values.tables.DictTable
 import kotlin.test.Test
 import kotlin.test.assertEquals
 
@@ -87,6 +91,27 @@ class AbstractionTests {
                 ).inferType(
                     scope = GlobalStaticScope,
                 ),
+            )
+        }
+
+        @Test
+        fun testWithMetaArgument() {
+            val type = Expression.parse(
+                source = "![t] [n: Int] => false",
+            ).validateAndInferType(
+                scope = GlobalStaticScope,
+            )
+
+            assertEquals(
+                expected = AbstractionType(
+                    // TODO: Improve array typing
+                    metaArgumentType = ArrayType(
+                        elementType = MetaType,
+                    ),
+                    argumentType = IntCollectiveType,
+                    imageType = BoolType,
+                ),
+                actual = type,
             )
         }
     }

--- a/src/test/kotlin/sigma/expressions/AbstractionTests.kt
+++ b/src/test/kotlin/sigma/expressions/AbstractionTests.kt
@@ -1,10 +1,11 @@
 package sigma.expressions
 
 import sigma.GlobalStaticScope
-import sigma.TypeExpression
 import sigma.TypeReference
 import sigma.types.AbstractionType
 import sigma.types.IntCollectiveType
+import sigma.types.IntLiteralType
+import sigma.types.UndefinedType
 import sigma.values.IntValue
 import sigma.values.Symbol
 import kotlin.test.Test
@@ -43,6 +44,21 @@ class AbstractionTests {
                 ),
                 actual = Expression.parse(
                     source = "[n: Int] => n",
+                ).inferType(
+                    scope = GlobalStaticScope,
+                ),
+            )
+        }
+
+        @Test
+        fun testUnannotatedArgument() {
+            assertEquals(
+                expected = AbstractionType(
+                    argumentType = UndefinedType,
+                    imageType = IntLiteralType(IntValue.Zero),
+                ),
+                actual = Expression.parse(
+                    source = "[a] => 0",
                 ).inferType(
                     scope = GlobalStaticScope,
                 ),

--- a/src/test/kotlin/sigma/expressions/AbstractionTests.kt
+++ b/src/test/kotlin/sigma/expressions/AbstractionTests.kt
@@ -2,6 +2,7 @@ package sigma.expressions
 
 import sigma.GlobalStaticScope
 import sigma.TypeReference
+import sigma.expressions.Abstraction.MetaArgumentExpression
 import sigma.types.AbstractionType
 import sigma.types.IntCollectiveType
 import sigma.types.IntLiteralType
@@ -29,6 +30,30 @@ class AbstractionTests {
                 ),
                 actual = Expression.parse(
                     source = "[n: Int] => 0",
+                ),
+            )
+        }
+
+        @Test
+        fun testWithMetaArgument() {
+            assertEquals(
+                expected = Abstraction(
+                    location = SourceLocation(lineIndex = 1, columnIndex = 0),
+                    metaArgument = MetaArgumentExpression(
+                        location = SourceLocation(lineIndex = 1, columnIndex = 1),
+                        name = Symbol.of("t"),
+                    ),
+                    argumentName = Symbol.of("n"),
+                    argumentType = TypeReference(
+                        referee = Symbol.of("Int"),
+                    ),
+                    image = IntLiteral(
+                        SourceLocation(lineIndex = 1, columnIndex = 17),
+                        value = IntValue(0),
+                    ),
+                ),
+                actual = Expression.parse(
+                    source = "![t] [n: Int] => 0",
                 ),
             )
         }

--- a/src/test/kotlin/sigma/expressions/LetExpressionTests.kt
+++ b/src/test/kotlin/sigma/expressions/LetExpressionTests.kt
@@ -103,7 +103,26 @@ class LetExpressionTests {
                         b = a,
                     } in b
                 """.trimIndent()
-            ).inferType(
+            ).validateAndInferType(
+                scope = GlobalStaticScope,
+            )
+
+            assertEquals(
+                expected = BoolType,
+                actual = type,
+            )
+        }
+
+        @Test
+        fun testInferredFunctionType() {
+            val type = Expression.parse(
+                source = """
+                    let {
+                        f = [n: Int] => false,
+                        a = f[0],
+                    } in a
+                """.trimIndent()
+            ).validateAndInferType(
                 scope = GlobalStaticScope,
             )
 

--- a/src/test/kotlin/sigma/expressions/LetExpressionTests.kt
+++ b/src/test/kotlin/sigma/expressions/LetExpressionTests.kt
@@ -71,7 +71,7 @@ class LetExpressionTests {
                         Declaration(
                             name = Symbol.of("a"),
                             valueType = TypeReference(
-                                Symbol.of("Int"),
+                                referee = Symbol.of("Int"),
                             ),
                             value = Reference(
                                 location = SourceLocation(lineIndex = 1, columnIndex = 15),

--- a/src/test/kotlin/sigma/programs/euler/EulerProblemsTests.kt
+++ b/src/test/kotlin/sigma/programs/euler/EulerProblemsTests.kt
@@ -23,8 +23,6 @@ class EulerProblemsTests {
     }
 
     @Test
-    // TODO: Re-enable
-    @Disabled
     fun testProblem7() {
         // For 20th prime (for performance reasons)
         assertEquals(

--- a/src/test/kotlin/sigma/programs/euler/EulerProblemsTests.kt
+++ b/src/test/kotlin/sigma/programs/euler/EulerProblemsTests.kt
@@ -2,7 +2,6 @@ package sigma.programs.euler
 
 import org.antlr.v4.runtime.CharStreams
 import org.antlr.v4.runtime.CommonTokenStream
-import org.junit.jupiter.api.Disabled
 import sigma.GlobalStaticScope
 import sigma.values.BoolValue
 import sigma.expressions.Expression
@@ -73,7 +72,7 @@ private fun solveProblem(n: Int): Value {
 
     val result = root.evaluateAsRoot()
 
-    return result.obtain()
+    return result.toEvaluatedValue
 }
 
 private fun getResourceAsText(


### PR DESCRIPTION
- Add location info to type errors
- Improve handling of unannotated arguments
- Re-enable `testProblem7`
- Rename `obtain` to `toEvaluatedValue`
- Introduce `BoundThunk` class
- Add `ArrayType` helper
- Introduce meta-argument syntax
- Introduce meta-argument typing
