### PR TITLE
namespace entry 1

### DIFF
--- a/analyzer/src/main/antlr/SigmaParser.g4
+++ b/analyzer/src/main/antlr/SigmaParser.g4
@@ -15,7 +15,7 @@ importStatement
     ;
 
 importPath
-    : identifier (Dot identifier)*
+    : (packagePathSegment+=identifier Dot)* moduleName=identifier
     ;
 
 namespaceEntry

--- a/analyzer/src/main/kotlin/com/github/cubuspl42/sigmaLang/analyzer/evaluation/scope/ChainedDynamicScope.kt
+++ b/analyzer/src/main/kotlin/com/github/cubuspl42/sigmaLang/analyzer/evaluation/scope/ChainedDynamicScope.kt
@@ -4,15 +4,15 @@ import com.github.cubuspl42.sigmaLang.analyzer.evaluation.values.Symbol
 import com.github.cubuspl42.sigmaLang.analyzer.evaluation.values.Thunk
 import com.github.cubuspl42.sigmaLang.analyzer.evaluation.values.Value
 
-class ChainedScope(
-    private val outerScope: Scope,
-    private val scope: Scope,
-) : Scope {
+class ChainedDynamicScope(
+    private val outerDynamicScope: DynamicScope,
+    private val dynamicScope: DynamicScope,
+) : DynamicScope {
     override fun getValue(
         name: Symbol,
-    ): Thunk<Value>? = scope.getValue(
+    ): Thunk<Value>? = dynamicScope.getValue(
         name = name,
-    ) ?: outerScope.getValue(
+    ) ?: outerDynamicScope.getValue(
         name = name,
     )
 }

--- a/analyzer/src/main/kotlin/com/github/cubuspl42/sigmaLang/analyzer/evaluation/scope/DynamicScope.kt
+++ b/analyzer/src/main/kotlin/com/github/cubuspl42/sigmaLang/analyzer/evaluation/scope/DynamicScope.kt
@@ -4,8 +4,8 @@ import com.github.cubuspl42.sigmaLang.analyzer.evaluation.values.Symbol
 import com.github.cubuspl42.sigmaLang.analyzer.evaluation.values.Thunk
 import com.github.cubuspl42.sigmaLang.analyzer.evaluation.values.Value
 
-interface Scope {
-    object Empty : Scope {
+interface DynamicScope {
+    object Empty : DynamicScope {
         override fun getValue(name: Symbol): Thunk<Value>? = null
     }
 
@@ -14,9 +14,9 @@ interface Scope {
     ): Thunk<Value>?
 }
 
-fun Scope.chainWith(
-    context: Scope,
-): Scope = ChainedScope(
-    outerScope = context,
-    scope = this,
+fun DynamicScope.chainWith(
+    context: DynamicScope,
+): DynamicScope = ChainedDynamicScope(
+    outerDynamicScope = context,
+    dynamicScope = this,
 )

--- a/analyzer/src/main/kotlin/com/github/cubuspl42/sigmaLang/analyzer/evaluation/scope/FixedDynamicScope.kt
+++ b/analyzer/src/main/kotlin/com/github/cubuspl42/sigmaLang/analyzer/evaluation/scope/FixedDynamicScope.kt
@@ -5,9 +5,9 @@ import com.github.cubuspl42.sigmaLang.analyzer.evaluation.values.Thunk
 import com.github.cubuspl42.sigmaLang.analyzer.evaluation.values.Value
 import com.github.cubuspl42.sigmaLang.analyzer.evaluation.values.asThunk
 
-class FixedScope(
+class FixedDynamicScope(
     private val entries: Map<Symbol, Value>,
-) : Scope {
+) : DynamicScope {
     override fun getValue(
         name: Symbol,
     ): Thunk<Value>? = entries[name]?.asThunk

--- a/analyzer/src/main/kotlin/com/github/cubuspl42/sigmaLang/analyzer/evaluation/scope/LoopedDynamicScope.kt
+++ b/analyzer/src/main/kotlin/com/github/cubuspl42/sigmaLang/analyzer/evaluation/scope/LoopedDynamicScope.kt
@@ -5,10 +5,10 @@ import com.github.cubuspl42.sigmaLang.analyzer.evaluation.values.Thunk
 import com.github.cubuspl42.sigmaLang.analyzer.evaluation.values.Value
 import com.github.cubuspl42.sigmaLang.analyzer.semantics.expressions.Expression
 
-class LoopedScope(
-    private val outerScope: Scope,
+class LoopedDynamicScope(
+    private val outerDynamicScope: DynamicScope,
     private val expressionByName: Map<Symbol, Expression>,
-) : Scope {
+) : DynamicScope {
     private val valueByName = mutableMapOf<Symbol, Thunk<Value>?>()
 
     override fun getValue(
@@ -16,9 +16,9 @@ class LoopedScope(
     ): Thunk<Value>? = valueByName.getOrPut(name) {
         expressionByName[name]?.let {
             Thunk.lazy {
-                it.bind(scope = this@LoopedScope)
+                it.bind(dynamicScope = this@LoopedDynamicScope)
             }
-        } ?: outerScope.getValue(
+        } ?: outerDynamicScope.getValue(
             name = name,
         )
     }

--- a/analyzer/src/main/kotlin/com/github/cubuspl42/sigmaLang/analyzer/evaluation/values/Closure.kt
+++ b/analyzer/src/main/kotlin/com/github/cubuspl42/sigmaLang/analyzer/evaluation/values/Closure.kt
@@ -1,22 +1,22 @@
 package com.github.cubuspl42.sigmaLang.analyzer.evaluation.values
 
-import com.github.cubuspl42.sigmaLang.analyzer.evaluation.scope.Scope
+import com.github.cubuspl42.sigmaLang.analyzer.evaluation.scope.DynamicScope
 import com.github.cubuspl42.sigmaLang.analyzer.evaluation.scope.chainWith
 import com.github.cubuspl42.sigmaLang.analyzer.semantics.expressions.Expression
 import com.github.cubuspl42.sigmaLang.analyzer.semantics.types.TupleType
 
 class Closure(
-    private val outerScope: Scope,
+    private val outerDynamicScope: DynamicScope,
     private val argumentType: TupleType,
     private val image: Expression,
 ) : ComputableFunctionValue() {
     override fun apply(
         argument: Value,
     ): Thunk<Value> = image.bind(
-        scope = argumentType.toArgumentScope(
+        dynamicScope = argumentType.toArgumentScope(
             argument = argument as DictValue,
         ).chainWith(
-            context = outerScope,
+            context = outerDynamicScope,
         ),
     )
 

--- a/analyzer/src/main/kotlin/com/github/cubuspl42/sigmaLang/analyzer/semantics/BuiltinScope.kt
+++ b/analyzer/src/main/kotlin/com/github/cubuspl42/sigmaLang/analyzer/semantics/BuiltinScope.kt
@@ -30,9 +30,9 @@ private class BuiltinValueDefinition(
     val value: Value,
     val type: Type,
 ) : NamespaceEntry() {
-//    override val effectiveValueType: Computation<Type> = Computation.pure(type)
+    override val valueThunk: Thunk<Value> = value.asThunk
 
-    override val staticValue: Thunk<Value> = value.asThunk
+    override val effectiveType: Thunk<Type> = Thunk.pure(type)
 
     override val expressionMap: ExpressionMap = ExpressionMap.Empty
 
@@ -42,8 +42,8 @@ private class BuiltinValueDefinition(
     val asResolvedName: ResolvedName
         get() = ResolvedName(
             type = type.asThunk,
-            resolution = BuiltinResolution(
-                builtinValue = value,
+            resolution = StaticResolution(
+                namespaceEntry = this,
             ),
         )
 }

--- a/analyzer/src/main/kotlin/com/github/cubuspl42/sigmaLang/analyzer/semantics/BuiltinScope.kt
+++ b/analyzer/src/main/kotlin/com/github/cubuspl42/sigmaLang/analyzer/semantics/BuiltinScope.kt
@@ -1,6 +1,6 @@
 package com.github.cubuspl42.sigmaLang.analyzer.semantics
 
-import com.github.cubuspl42.sigmaLang.analyzer.evaluation.scope.Scope
+import com.github.cubuspl42.sigmaLang.analyzer.evaluation.scope.DynamicScope
 import com.github.cubuspl42.sigmaLang.analyzer.evaluation.values.BoolValue
 import com.github.cubuspl42.sigmaLang.analyzer.evaluation.values.FunctionValue
 import com.github.cubuspl42.sigmaLang.analyzer.evaluation.values.IntValue
@@ -48,7 +48,7 @@ private class BuiltinValueDefinition(
         )
 }
 
-object BuiltinScope : Scope, StaticScope {
+object BuiltinScope : DynamicScope, StaticScope {
     data class SimpleBuiltinValue(
         override val type: Type,
         override val value: Value,

--- a/analyzer/src/main/kotlin/com/github/cubuspl42/sigmaLang/analyzer/semantics/ConstantDefinition.kt
+++ b/analyzer/src/main/kotlin/com/github/cubuspl42/sigmaLang/analyzer/semantics/ConstantDefinition.kt
@@ -6,6 +6,7 @@ import com.github.cubuspl42.sigmaLang.analyzer.evaluation.values.Thunk
 import com.github.cubuspl42.sigmaLang.analyzer.evaluation.values.Value
 import com.github.cubuspl42.sigmaLang.analyzer.semantics.expressions.Expression
 import com.github.cubuspl42.sigmaLang.analyzer.semantics.expressions.ExpressionMap
+import com.github.cubuspl42.sigmaLang.analyzer.semantics.types.Type
 import com.github.cubuspl42.sigmaLang.analyzer.syntax.ConstantDefinitionTerm
 
 class ConstantDefinition(
@@ -48,16 +49,14 @@ class ConstantDefinition(
 
     val asValueDefinition = ConstantValueDefinition()
 
-    val valueThunk by lazy {
+    override val valueThunk by lazy {
         asValueDefinition.body.bind(
             dynamicScope = containingNamespace.innerDynamicScope,
         )
     }
 
-    fun evaluateResult(): EvaluationOutcome<Value> = valueThunk.evaluateInitial()
-
-    override val staticValue: Thunk<Value>
-        get() = this.valueThunk
+    override val effectiveType: Thunk<Type>
+        get() = asValueDefinition.effectiveValueType
 
     override val expressionMap: ExpressionMap
         get() = asValueDefinition.body.expressionMap

--- a/analyzer/src/main/kotlin/com/github/cubuspl42/sigmaLang/analyzer/semantics/ConstantDefinition.kt
+++ b/analyzer/src/main/kotlin/com/github/cubuspl42/sigmaLang/analyzer/semantics/ConstantDefinition.kt
@@ -1,5 +1,6 @@
 package com.github.cubuspl42.sigmaLang.analyzer.semantics
 
+import com.github.cubuspl42.sigmaLang.analyzer.evaluation.values.EvaluationOutcome
 import com.github.cubuspl42.sigmaLang.analyzer.evaluation.values.Symbol
 import com.github.cubuspl42.sigmaLang.analyzer.evaluation.values.Thunk
 import com.github.cubuspl42.sigmaLang.analyzer.evaluation.values.Value
@@ -52,6 +53,8 @@ class ConstantDefinition(
             scope = containingNamespace.innerScope,
         )
     }
+
+    fun evaluateResult(): EvaluationOutcome<Value> = valueThunk.evaluateInitial()
 
     override val staticValue: Thunk<Value>
         get() = this.valueThunk

--- a/analyzer/src/main/kotlin/com/github/cubuspl42/sigmaLang/analyzer/semantics/ConstantDefinition.kt
+++ b/analyzer/src/main/kotlin/com/github/cubuspl42/sigmaLang/analyzer/semantics/ConstantDefinition.kt
@@ -50,7 +50,7 @@ class ConstantDefinition(
 
     val valueThunk by lazy {
         asValueDefinition.body.bind(
-            scope = containingNamespace.innerScope,
+            dynamicScope = containingNamespace.innerDynamicScope,
         )
     }
 

--- a/analyzer/src/main/kotlin/com/github/cubuspl42/sigmaLang/analyzer/semantics/LocalValueDefinitionBlock.kt
+++ b/analyzer/src/main/kotlin/com/github/cubuspl42/sigmaLang/analyzer/semantics/LocalValueDefinitionBlock.kt
@@ -1,7 +1,7 @@
 package com.github.cubuspl42.sigmaLang.analyzer.semantics
 
-import com.github.cubuspl42.sigmaLang.analyzer.evaluation.scope.LoopedScope
-import com.github.cubuspl42.sigmaLang.analyzer.evaluation.scope.Scope
+import com.github.cubuspl42.sigmaLang.analyzer.evaluation.scope.LoopedDynamicScope
+import com.github.cubuspl42.sigmaLang.analyzer.evaluation.scope.DynamicScope
 import com.github.cubuspl42.sigmaLang.analyzer.evaluation.values.Symbol
 import com.github.cubuspl42.sigmaLang.analyzer.syntax.LocalDefinitionTerm
 
@@ -49,9 +49,9 @@ class LocalValueDefinitionBlock(
     }
 
     fun evaluate(
-        scope: Scope,
-    ): Scope = LoopedScope(
-        outerScope = scope,
+        dynamicScope: DynamicScope,
+    ): DynamicScope = LoopedDynamicScope(
+        outerDynamicScope = dynamicScope,
         expressionByName = definitionByName.mapValues { (_, definition) ->
             definition.body
         },

--- a/analyzer/src/main/kotlin/com/github/cubuspl42/sigmaLang/analyzer/semantics/Namespace.kt
+++ b/analyzer/src/main/kotlin/com/github/cubuspl42/sigmaLang/analyzer/semantics/Namespace.kt
@@ -1,6 +1,6 @@
 package com.github.cubuspl42.sigmaLang.analyzer.semantics
 
-import com.github.cubuspl42.sigmaLang.analyzer.evaluation.scope.Scope
+import com.github.cubuspl42.sigmaLang.analyzer.evaluation.scope.DynamicScope
 import com.github.cubuspl42.sigmaLang.analyzer.evaluation.scope.chainWith
 import com.github.cubuspl42.sigmaLang.analyzer.evaluation.values.Symbol
 import com.github.cubuspl42.sigmaLang.analyzer.evaluation.values.Thunk
@@ -59,7 +59,7 @@ class Namespace(
         outerScope = prelude.declarationScope,
     )
 
-    val innerScope = object : Scope {
+    val innerDynamicScope = object : DynamicScope {
         override fun getValue(
             name: Symbol,
         ): Thunk<Value>? {
@@ -67,7 +67,7 @@ class Namespace(
             return constantDefinition?.staticValue
         }
     }.chainWith(
-        context = prelude.scope,
+        context = prelude.dynamicScope,
     )
 
 

--- a/analyzer/src/main/kotlin/com/github/cubuspl42/sigmaLang/analyzer/semantics/Namespace.kt
+++ b/analyzer/src/main/kotlin/com/github/cubuspl42/sigmaLang/analyzer/semantics/Namespace.kt
@@ -11,7 +11,7 @@ import com.github.cubuspl42.sigmaLang.analyzer.syntax.NamespaceDefinitionTerm
 class Namespace(
     private val prelude: Prelude,
     private val term: NamespaceDefinitionTerm,
-) : Value() {
+) {
     companion object {
         fun build(
             prelude: Prelude,
@@ -74,6 +74,4 @@ class Namespace(
     fun printErrors() {
         errors.forEach { println(it.dump()) }
     }
-
-    override fun dump(): String = "(namespace)"
 }

--- a/analyzer/src/main/kotlin/com/github/cubuspl42/sigmaLang/analyzer/semantics/NamespaceEntry.kt
+++ b/analyzer/src/main/kotlin/com/github/cubuspl42/sigmaLang/analyzer/semantics/NamespaceEntry.kt
@@ -1,8 +1,10 @@
 package com.github.cubuspl42.sigmaLang.analyzer.semantics
 
+import com.github.cubuspl42.sigmaLang.analyzer.evaluation.values.EvaluationOutcome
 import com.github.cubuspl42.sigmaLang.analyzer.evaluation.values.Thunk
 import com.github.cubuspl42.sigmaLang.analyzer.evaluation.values.Value
 import com.github.cubuspl42.sigmaLang.analyzer.semantics.expressions.ExpressionMap
+import com.github.cubuspl42.sigmaLang.analyzer.semantics.types.Type
 import com.github.cubuspl42.sigmaLang.analyzer.syntax.*
 
 abstract class NamespaceEntry : Declaration {
@@ -22,7 +24,11 @@ abstract class NamespaceEntry : Declaration {
         }
     }
 
-    abstract val staticValue: Thunk<Value>
+    fun evaluateResult(): EvaluationOutcome<Value> = valueThunk.evaluateInitial()
+
+    abstract val valueThunk: Thunk<Value>
+
+    abstract val effectiveType: Thunk<Type>
 
     abstract val expressionMap: ExpressionMap
 

--- a/analyzer/src/main/kotlin/com/github/cubuspl42/sigmaLang/analyzer/semantics/Prelude.kt
+++ b/analyzer/src/main/kotlin/com/github/cubuspl42/sigmaLang/analyzer/semantics/Prelude.kt
@@ -2,11 +2,11 @@ package com.github.cubuspl42.sigmaLang.analyzer.semantics
 
 import getResourceAsText
 import com.github.cubuspl42.sigmaLang.analyzer.syntax.expressions.LocalScopeSourceTerm
-import com.github.cubuspl42.sigmaLang.analyzer.evaluation.scope.Scope
+import com.github.cubuspl42.sigmaLang.analyzer.evaluation.scope.DynamicScope
 
 data class Prelude(
     val declarationScope: StaticScope,
-    val scope: Scope,
+    val dynamicScope: DynamicScope,
 ) {
     companion object {
         fun load(): Prelude {
@@ -30,12 +30,12 @@ data class Prelude(
             }
 
             val preludeScope = definitionBlock.evaluate(
-                scope = BuiltinScope,
+                dynamicScope = BuiltinScope,
             )
 
             return Prelude(
                 declarationScope = declarationScope,
-                scope = preludeScope,
+                dynamicScope = preludeScope,
             )
         }
     }

--- a/analyzer/src/main/kotlin/com/github/cubuspl42/sigmaLang/analyzer/semantics/Program.kt
+++ b/analyzer/src/main/kotlin/com/github/cubuspl42/sigmaLang/analyzer/semantics/Program.kt
@@ -26,10 +26,10 @@ class Program internal constructor(
     val errors: Set<SemanticError> by lazy { module.errors }
 
     fun evaluateResult(): EvaluationOutcome<Value> {
-        val result = module.rootNamespace.getConstantDefinition(
+        val result = module.rootNamespace.getEntry(
             name = Symbol.of("main")
         )!!
 
-        return result.staticValue.evaluateInitial()
+        return result.valueThunk.evaluateInitial()
     }
 }

--- a/analyzer/src/main/kotlin/com/github/cubuspl42/sigmaLang/analyzer/semantics/Project.kt
+++ b/analyzer/src/main/kotlin/com/github/cubuspl42/sigmaLang/analyzer/semantics/Project.kt
@@ -63,8 +63,8 @@ class Project(
     val errors: Set<SemanticError>
         get() = mainModule.errors
 
-    val entryPoint: ConstantDefinition
-        get() = mainModule.rootNamespace.getConstantDefinition(
+    val entryPoint: NamespaceEntry
+        get() = mainModule.rootNamespace.getEntry(
             name = Symbol.of("main"),
         )!!
 }

--- a/analyzer/src/main/kotlin/com/github/cubuspl42/sigmaLang/analyzer/semantics/ProjectStore.kt
+++ b/analyzer/src/main/kotlin/com/github/cubuspl42/sigmaLang/analyzer/semantics/ProjectStore.kt
@@ -1,0 +1,5 @@
+package com.github.cubuspl42.sigmaLang.analyzer.semantics
+
+interface ProjectStore {
+    fun load(modulePath: ModulePath): String
+}

--- a/analyzer/src/main/kotlin/com/github/cubuspl42/sigmaLang/analyzer/semantics/Resolution.kt
+++ b/analyzer/src/main/kotlin/com/github/cubuspl42/sigmaLang/analyzer/semantics/Resolution.kt
@@ -3,7 +3,6 @@ package com.github.cubuspl42.sigmaLang.analyzer.semantics
 import com.github.cubuspl42.sigmaLang.analyzer.evaluation.values.Symbol
 import com.github.cubuspl42.sigmaLang.analyzer.evaluation.values.Thunk
 import com.github.cubuspl42.sigmaLang.analyzer.evaluation.values.Value
-import com.github.cubuspl42.sigmaLang.analyzer.evaluation.values.asThunk
 import com.github.cubuspl42.sigmaLang.analyzer.semantics.types.Type
 
 data class Formula(
@@ -16,28 +15,16 @@ data class Formula(
     }
 }
 
-sealed class Resolution {}
+sealed class Resolution
 
 class DynamicResolution(
     val resolvedFormula: Formula?,
 ) : Resolution()
 
-abstract class StaticResolution : Resolution() {
-    abstract val resolvedValue: Thunk<Value>
-}
-
-class BuiltinResolution(
-    val builtinValue: Value,
-) : StaticResolution() {
-    override val resolvedValue: Thunk<Value>
-        get() = builtinValue.asThunk
-}
-
-class ConstDefinitionResolution(
-    private val constantDefinition: ConstantDefinition,
-) : StaticResolution() {
-    override val resolvedValue: Thunk<Value>
-        get() = constantDefinition.valueThunk
+class StaticResolution(
+    private val namespaceEntry: NamespaceEntry,
+) : Resolution() {
+    val resolvedValue: Thunk<Value> = namespaceEntry.valueThunk
 }
 
 data class ResolvedName(

--- a/analyzer/src/main/kotlin/com/github/cubuspl42/sigmaLang/analyzer/semantics/ResourceProjectStore.kt
+++ b/analyzer/src/main/kotlin/com/github/cubuspl42/sigmaLang/analyzer/semantics/ResourceProjectStore.kt
@@ -1,0 +1,9 @@
+package com.github.cubuspl42.sigmaLang.analyzer.semantics
+
+class ResourceProjectStore(private val javaClass: Class<*>) : ProjectStore {
+    override fun load(modulePath: ModulePath): String {
+        val fileName = "${modulePath.name}.sigma"
+        val content = javaClass.getResource(fileName)?.readText()
+        return content ?: throw RuntimeException("Couldn't load the source file: $fileName")
+    }
+}

--- a/analyzer/src/main/kotlin/com/github/cubuspl42/sigmaLang/analyzer/semantics/ValueDefinition.kt
+++ b/analyzer/src/main/kotlin/com/github/cubuspl42/sigmaLang/analyzer/semantics/ValueDefinition.kt
@@ -15,7 +15,7 @@ abstract class ValueDefinition : ValueDeclaration {
 
     private val declaredType: Thunk<Type>? by lazy {
         declaredTypeBody?.let { expression ->
-            expression.bind(scope = BuiltinScope).thenJust { it as Type }
+            expression.bind(dynamicScope = BuiltinScope).thenJust { it as Type }
         }
     }
 

--- a/analyzer/src/main/kotlin/com/github/cubuspl42/sigmaLang/analyzer/semantics/expressions/Abstraction.kt
+++ b/analyzer/src/main/kotlin/com/github/cubuspl42/sigmaLang/analyzer/semantics/expressions/Abstraction.kt
@@ -1,6 +1,6 @@
 package com.github.cubuspl42.sigmaLang.analyzer.semantics.expressions
 
-import com.github.cubuspl42.sigmaLang.analyzer.evaluation.scope.Scope
+import com.github.cubuspl42.sigmaLang.analyzer.evaluation.scope.DynamicScope
 import com.github.cubuspl42.sigmaLang.analyzer.evaluation.values.Closure
 import com.github.cubuspl42.sigmaLang.analyzer.evaluation.values.Symbol
 import com.github.cubuspl42.sigmaLang.analyzer.evaluation.values.Thunk
@@ -76,7 +76,7 @@ class Abstraction(
 
             val argumentType = argumentTypeBody.evaluateValue(
                 context = EvaluationContext.Initial,
-                scope = TranslationScope(
+                dynamicScope = TranslationDynamicScope(
                     staticScope = innerDeclarationScope1,
                 ),
             ) as TupleType
@@ -109,8 +109,8 @@ class Abstraction(
         }
     }
 
-    override fun bind(scope: Scope): Thunk<Value> = Closure(
-        outerScope = scope,
+    override fun bind(dynamicScope: DynamicScope): Thunk<Value> = Closure(
+        outerDynamicScope = dynamicScope,
         argumentType = argumentType,
         image = image,
     ).asThunk

--- a/analyzer/src/main/kotlin/com/github/cubuspl42/sigmaLang/analyzer/semantics/expressions/Abstraction.kt
+++ b/analyzer/src/main/kotlin/com/github/cubuspl42/sigmaLang/analyzer/semantics/expressions/Abstraction.kt
@@ -18,7 +18,6 @@ import com.github.cubuspl42.sigmaLang.analyzer.semantics.types.TupleType
 import com.github.cubuspl42.sigmaLang.analyzer.semantics.types.Type
 import com.github.cubuspl42.sigmaLang.analyzer.semantics.types.TypeVariable
 import com.github.cubuspl42.sigmaLang.analyzer.semantics.types.UniversalFunctionType
-import com.github.cubuspl42.sigmaLang.analyzer.syntax.expressions.AbstractionSourceTerm
 import com.github.cubuspl42.sigmaLang.analyzer.syntax.expressions.AbstractionTerm
 
 class Abstraction(

--- a/analyzer/src/main/kotlin/com/github/cubuspl42/sigmaLang/analyzer/semantics/expressions/ArrayTypeConstructor.kt
+++ b/analyzer/src/main/kotlin/com/github/cubuspl42/sigmaLang/analyzer/semantics/expressions/ArrayTypeConstructor.kt
@@ -7,9 +7,7 @@ import com.github.cubuspl42.sigmaLang.analyzer.semantics.SemanticError
 import com.github.cubuspl42.sigmaLang.analyzer.semantics.StaticScope
 import com.github.cubuspl42.sigmaLang.analyzer.semantics.types.ArrayType
 import com.github.cubuspl42.sigmaLang.analyzer.semantics.types.Type
-import com.github.cubuspl42.sigmaLang.analyzer.syntax.expressions.ArrayTypeConstructorSourceTerm
 import com.github.cubuspl42.sigmaLang.analyzer.syntax.expressions.ArrayTypeConstructorTerm
-import com.github.cubuspl42.sigmaLang.analyzer.syntax.expressions.ExpressionSourceTerm
 import com.github.cubuspl42.sigmaLang.analyzer.syntax.expressions.ExpressionTerm
 
 class ArrayTypeConstructor(

--- a/analyzer/src/main/kotlin/com/github/cubuspl42/sigmaLang/analyzer/semantics/expressions/ArrayTypeConstructor.kt
+++ b/analyzer/src/main/kotlin/com/github/cubuspl42/sigmaLang/analyzer/semantics/expressions/ArrayTypeConstructor.kt
@@ -1,6 +1,6 @@
 package com.github.cubuspl42.sigmaLang.analyzer.semantics.expressions
 
-import com.github.cubuspl42.sigmaLang.analyzer.evaluation.scope.Scope
+import com.github.cubuspl42.sigmaLang.analyzer.evaluation.scope.DynamicScope
 import com.github.cubuspl42.sigmaLang.analyzer.evaluation.values.Thunk
 import com.github.cubuspl42.sigmaLang.analyzer.evaluation.values.Value
 import com.github.cubuspl42.sigmaLang.analyzer.semantics.SemanticError
@@ -38,8 +38,8 @@ class ArrayTypeConstructor(
 
     override val errors: Set<SemanticError> = emptySet()
 
-    override fun bind(scope: Scope): Thunk<Value> = elementType.bind(
-        scope = scope,
+    override fun bind(dynamicScope: DynamicScope): Thunk<Value> = elementType.bind(
+        dynamicScope = dynamicScope,
     ).thenJust {
         ArrayType(elementType = it as Type)
     }

--- a/analyzer/src/main/kotlin/com/github/cubuspl42/sigmaLang/analyzer/semantics/expressions/Call.kt
+++ b/analyzer/src/main/kotlin/com/github/cubuspl42/sigmaLang/analyzer/semantics/expressions/Call.kt
@@ -1,7 +1,7 @@
 package com.github.cubuspl42.sigmaLang.analyzer.semantics.expressions
 
 import com.github.cubuspl42.sigmaLang.analyzer.BinaryOperationPrototype
-import com.github.cubuspl42.sigmaLang.analyzer.evaluation.scope.Scope
+import com.github.cubuspl42.sigmaLang.analyzer.evaluation.scope.DynamicScope
 import com.github.cubuspl42.sigmaLang.analyzer.evaluation.values.FunctionValue
 import com.github.cubuspl42.sigmaLang.analyzer.evaluation.values.Symbol
 import com.github.cubuspl42.sigmaLang.analyzer.evaluation.values.Thunk
@@ -212,12 +212,12 @@ class Call(
     override val subExpressions: Set<Expression> = setOf(subject, argument)
 
     override fun bind(
-        scope: Scope,
+        dynamicScope: DynamicScope,
     ): Thunk<Value> = Thunk.combine2(
         subject.bind(
-            scope = scope,
+            dynamicScope = dynamicScope,
         ), argument.bind(
-            scope = scope,
+            dynamicScope = dynamicScope,
         )
     ) { subjectValue, argumentValue ->
         if (subjectValue !is FunctionValue) throw IllegalStateException("Subject $subjectValue is not a function")

--- a/analyzer/src/main/kotlin/com/github/cubuspl42/sigmaLang/analyzer/semantics/expressions/DictConstructor.kt
+++ b/analyzer/src/main/kotlin/com/github/cubuspl42/sigmaLang/analyzer/semantics/expressions/DictConstructor.kt
@@ -12,7 +12,6 @@ import com.github.cubuspl42.sigmaLang.analyzer.semantics.types.IllType
 import com.github.cubuspl42.sigmaLang.analyzer.semantics.types.PrimitiveType
 import com.github.cubuspl42.sigmaLang.analyzer.semantics.types.Type
 import com.github.cubuspl42.sigmaLang.analyzer.syntax.SourceLocation
-import com.github.cubuspl42.sigmaLang.analyzer.syntax.expressions.DictConstructorSourceTerm
 import com.github.cubuspl42.sigmaLang.analyzer.syntax.expressions.DictConstructorTerm
 import com.github.cubuspl42.sigmaLang.analyzer.utils.SetUtils
 

--- a/analyzer/src/main/kotlin/com/github/cubuspl42/sigmaLang/analyzer/semantics/expressions/DictConstructor.kt
+++ b/analyzer/src/main/kotlin/com/github/cubuspl42/sigmaLang/analyzer/semantics/expressions/DictConstructor.kt
@@ -1,6 +1,6 @@
 package com.github.cubuspl42.sigmaLang.analyzer.semantics.expressions
 
-import com.github.cubuspl42.sigmaLang.analyzer.evaluation.scope.Scope
+import com.github.cubuspl42.sigmaLang.analyzer.evaluation.scope.DynamicScope
 import com.github.cubuspl42.sigmaLang.analyzer.evaluation.values.DictValue
 import com.github.cubuspl42.sigmaLang.analyzer.evaluation.values.PrimitiveValue
 import com.github.cubuspl42.sigmaLang.analyzer.evaluation.values.Thunk
@@ -151,14 +151,14 @@ class DictConstructor(
     override val subExpressions: Set<Expression> = SetUtils.unionAllOf(associations) { setOf(it.key, it.value) }
 
     override fun bind(
-        scope: Scope,
+        dynamicScope: DynamicScope,
     ): Thunk<Value> = Thunk.traverseList(associations) { association ->
         Thunk.combine2(
             association.key.bind(
-                scope = scope,
+                dynamicScope = dynamicScope,
             ),
             association.value.bind(
-                scope = scope,
+                dynamicScope = dynamicScope,
             ),
         ) { key, value ->
             (key as PrimitiveValue) to value

--- a/analyzer/src/main/kotlin/com/github/cubuspl42/sigmaLang/analyzer/semantics/expressions/DictTypeConstructor.kt
+++ b/analyzer/src/main/kotlin/com/github/cubuspl42/sigmaLang/analyzer/semantics/expressions/DictTypeConstructor.kt
@@ -1,6 +1,6 @@
 package com.github.cubuspl42.sigmaLang.analyzer.semantics.expressions
 
-import com.github.cubuspl42.sigmaLang.analyzer.evaluation.scope.Scope
+import com.github.cubuspl42.sigmaLang.analyzer.evaluation.scope.DynamicScope
 import com.github.cubuspl42.sigmaLang.analyzer.evaluation.values.Thunk
 import com.github.cubuspl42.sigmaLang.analyzer.evaluation.values.Value
 import com.github.cubuspl42.sigmaLang.analyzer.semantics.SemanticError
@@ -42,12 +42,12 @@ class DictTypeConstructor(
     override val errors: Set<SemanticError> = emptySet()
 
     override fun bind(
-        scope: Scope,
+        dynamicScope: DynamicScope,
     ): Thunk<Value> = Thunk.combine2(
         keyType.bind(
-            scope = scope,
+            dynamicScope = dynamicScope,
         ), valueType.bind(
-            scope = scope,
+            dynamicScope = dynamicScope,
         )
     ) { keyType, valueType ->
         DictType(

--- a/analyzer/src/main/kotlin/com/github/cubuspl42/sigmaLang/analyzer/semantics/expressions/DictTypeConstructor.kt
+++ b/analyzer/src/main/kotlin/com/github/cubuspl42/sigmaLang/analyzer/semantics/expressions/DictTypeConstructor.kt
@@ -7,9 +7,7 @@ import com.github.cubuspl42.sigmaLang.analyzer.semantics.SemanticError
 import com.github.cubuspl42.sigmaLang.analyzer.semantics.StaticScope
 import com.github.cubuspl42.sigmaLang.analyzer.semantics.types.DictType
 import com.github.cubuspl42.sigmaLang.analyzer.semantics.types.Type
-import com.github.cubuspl42.sigmaLang.analyzer.syntax.expressions.DictTypeConstructorSourceTerm
 import com.github.cubuspl42.sigmaLang.analyzer.syntax.expressions.DictTypeConstructorTerm
-import com.github.cubuspl42.sigmaLang.analyzer.syntax.expressions.ExpressionSourceTerm
 import com.github.cubuspl42.sigmaLang.analyzer.syntax.expressions.ExpressionTerm
 
 class DictTypeConstructor(

--- a/analyzer/src/main/kotlin/com/github/cubuspl42/sigmaLang/analyzer/semantics/expressions/Expression.kt
+++ b/analyzer/src/main/kotlin/com/github/cubuspl42/sigmaLang/analyzer/semantics/expressions/Expression.kt
@@ -1,6 +1,6 @@
 package com.github.cubuspl42.sigmaLang.analyzer.semantics.expressions
 
-import com.github.cubuspl42.sigmaLang.analyzer.evaluation.scope.Scope
+import com.github.cubuspl42.sigmaLang.analyzer.evaluation.scope.DynamicScope
 import com.github.cubuspl42.sigmaLang.analyzer.evaluation.values.Thunk
 import com.github.cubuspl42.sigmaLang.analyzer.evaluation.values.Value
 import com.github.cubuspl42.sigmaLang.analyzer.evaluation.values.evaluateValueHacky
@@ -139,17 +139,17 @@ abstract class Expression {
 
     fun evaluateValue(
         context: EvaluationContext,
-        scope: Scope,
-    ): Value? = bind(scope = scope).evaluateValueHacky(context = context)
+        dynamicScope: DynamicScope,
+    ): Value? = bind(dynamicScope = dynamicScope).evaluateValueHacky(context = context)
 
     abstract fun bind(
-        scope: Scope,
+        dynamicScope: DynamicScope,
     ): Thunk<Value>
 
     fun bindTranslated(
         staticScope: StaticScope,
     ): Thunk<Value> = bind(
-        scope = TranslationScope(
+        dynamicScope = TranslationDynamicScope(
             staticScope = staticScope,
         ),
     )

--- a/analyzer/src/main/kotlin/com/github/cubuspl42/sigmaLang/analyzer/semantics/expressions/FieldRead.kt
+++ b/analyzer/src/main/kotlin/com/github/cubuspl42/sigmaLang/analyzer/semantics/expressions/FieldRead.kt
@@ -1,6 +1,6 @@
 package com.github.cubuspl42.sigmaLang.analyzer.semantics.expressions
 
-import com.github.cubuspl42.sigmaLang.analyzer.evaluation.scope.Scope
+import com.github.cubuspl42.sigmaLang.analyzer.evaluation.scope.DynamicScope
 import com.github.cubuspl42.sigmaLang.analyzer.evaluation.values.DictValue
 import com.github.cubuspl42.sigmaLang.analyzer.evaluation.values.Symbol
 import com.github.cubuspl42.sigmaLang.analyzer.evaluation.values.Thunk
@@ -112,8 +112,8 @@ class FieldRead(
         }
     }
 
-    override fun bind(scope: Scope): Thunk<Value> = subject.bind(
-        scope = scope,
+    override fun bind(dynamicScope: DynamicScope): Thunk<Value> = subject.bind(
+        dynamicScope = dynamicScope,
     ).thenDo { subjectValue ->
         if (subjectValue !is DictValue) throw IllegalStateException("Subject $subjectValue is not a dict")
 

--- a/analyzer/src/main/kotlin/com/github/cubuspl42/sigmaLang/analyzer/semantics/expressions/FieldRead.kt
+++ b/analyzer/src/main/kotlin/com/github/cubuspl42/sigmaLang/analyzer/semantics/expressions/FieldRead.kt
@@ -11,7 +11,6 @@ import com.github.cubuspl42.sigmaLang.analyzer.semantics.types.IllType
 import com.github.cubuspl42.sigmaLang.analyzer.semantics.types.Type
 import com.github.cubuspl42.sigmaLang.analyzer.semantics.types.UnorderedTupleType
 import com.github.cubuspl42.sigmaLang.analyzer.syntax.SourceLocation
-import com.github.cubuspl42.sigmaLang.analyzer.syntax.expressions.FieldReadSourceTerm
 import com.github.cubuspl42.sigmaLang.analyzer.syntax.expressions.FieldReadTerm
 
 class FieldRead(

--- a/analyzer/src/main/kotlin/com/github/cubuspl42/sigmaLang/analyzer/semantics/expressions/FunctionTypeConstructor.kt
+++ b/analyzer/src/main/kotlin/com/github/cubuspl42/sigmaLang/analyzer/semantics/expressions/FunctionTypeConstructor.kt
@@ -1,6 +1,6 @@
 package com.github.cubuspl42.sigmaLang.analyzer.semantics.expressions
 
-import com.github.cubuspl42.sigmaLang.analyzer.evaluation.scope.Scope
+import com.github.cubuspl42.sigmaLang.analyzer.evaluation.scope.DynamicScope
 import com.github.cubuspl42.sigmaLang.analyzer.evaluation.values.Thunk
 import com.github.cubuspl42.sigmaLang.analyzer.evaluation.values.Value
 import com.github.cubuspl42.sigmaLang.analyzer.semantics.SemanticError
@@ -37,12 +37,12 @@ class FunctionTypeConstructor(
     override val inferredType: Thunk<Type>
         get() = TODO()
 
-    override fun bind(scope: Scope): Thunk<Value> = Thunk.combine2(
+    override fun bind(dynamicScope: DynamicScope): Thunk<Value> = Thunk.combine2(
         argumentType.bind(
-            scope = scope,
+            dynamicScope = dynamicScope,
         ),
         imageType.bind(
-            scope = scope,
+            dynamicScope = dynamicScope,
         ),
     ) { argumentType, imageType ->
         UniversalFunctionType(

--- a/analyzer/src/main/kotlin/com/github/cubuspl42/sigmaLang/analyzer/semantics/expressions/IfExpression.kt
+++ b/analyzer/src/main/kotlin/com/github/cubuspl42/sigmaLang/analyzer/semantics/expressions/IfExpression.kt
@@ -9,7 +9,6 @@ import com.github.cubuspl42.sigmaLang.analyzer.semantics.StaticScope
 import com.github.cubuspl42.sigmaLang.analyzer.semantics.types.BoolType
 import com.github.cubuspl42.sigmaLang.analyzer.semantics.types.Type
 import com.github.cubuspl42.sigmaLang.analyzer.syntax.SourceLocation
-import com.github.cubuspl42.sigmaLang.analyzer.syntax.expressions.IfExpressionSourceTerm
 import com.github.cubuspl42.sigmaLang.analyzer.syntax.expressions.IfExpressionTerm
 
 class IfExpression(

--- a/analyzer/src/main/kotlin/com/github/cubuspl42/sigmaLang/analyzer/semantics/expressions/IfExpression.kt
+++ b/analyzer/src/main/kotlin/com/github/cubuspl42/sigmaLang/analyzer/semantics/expressions/IfExpression.kt
@@ -1,6 +1,6 @@
 package com.github.cubuspl42.sigmaLang.analyzer.semantics.expressions
 
-import com.github.cubuspl42.sigmaLang.analyzer.evaluation.scope.Scope
+import com.github.cubuspl42.sigmaLang.analyzer.evaluation.scope.DynamicScope
 import com.github.cubuspl42.sigmaLang.analyzer.evaluation.values.BoolValue
 import com.github.cubuspl42.sigmaLang.analyzer.evaluation.values.Thunk
 import com.github.cubuspl42.sigmaLang.analyzer.evaluation.values.Value
@@ -73,18 +73,18 @@ class IfExpression(
         trueType.findLowestCommonSupertype(falseType)
     }
 
-    override fun bind(scope: Scope): Thunk<Value> = guard.bind(
-        scope = scope,
+    override fun bind(dynamicScope: DynamicScope): Thunk<Value> = guard.bind(
+        dynamicScope = dynamicScope,
     ).thenDo { guardValue ->
         if (guardValue !is BoolValue) throw IllegalArgumentException("Guard value $guardValue is not a boolean")
 
         if (guardValue.value) {
             trueBranch.bind(
-                scope = scope,
+                dynamicScope = dynamicScope,
             )
         } else {
             falseBranch.bind(
-                scope = scope,
+                dynamicScope = dynamicScope,
             )
         }
     }

--- a/analyzer/src/main/kotlin/com/github/cubuspl42/sigmaLang/analyzer/semantics/expressions/IntLiteral.kt
+++ b/analyzer/src/main/kotlin/com/github/cubuspl42/sigmaLang/analyzer/semantics/expressions/IntLiteral.kt
@@ -10,7 +10,6 @@ import com.github.cubuspl42.sigmaLang.analyzer.semantics.SemanticError
 import com.github.cubuspl42.sigmaLang.analyzer.semantics.StaticScope
 import com.github.cubuspl42.sigmaLang.analyzer.semantics.types.IntLiteralType
 import com.github.cubuspl42.sigmaLang.analyzer.semantics.types.Type
-import com.github.cubuspl42.sigmaLang.analyzer.syntax.expressions.IntLiteralSourceTerm
 import com.github.cubuspl42.sigmaLang.analyzer.syntax.expressions.IntLiteralTerm
 
 data class IntLiteral(

--- a/analyzer/src/main/kotlin/com/github/cubuspl42/sigmaLang/analyzer/semantics/expressions/IntLiteral.kt
+++ b/analyzer/src/main/kotlin/com/github/cubuspl42/sigmaLang/analyzer/semantics/expressions/IntLiteral.kt
@@ -1,7 +1,7 @@
 package com.github.cubuspl42.sigmaLang.analyzer.semantics.expressions
 
 
-import com.github.cubuspl42.sigmaLang.analyzer.evaluation.scope.Scope
+import com.github.cubuspl42.sigmaLang.analyzer.evaluation.scope.DynamicScope
 import com.github.cubuspl42.sigmaLang.analyzer.evaluation.values.IntValue
 import com.github.cubuspl42.sigmaLang.analyzer.evaluation.values.Thunk
 import com.github.cubuspl42.sigmaLang.analyzer.evaluation.values.Value
@@ -41,6 +41,6 @@ data class IntLiteral(
     override val errors: Set<SemanticError> = emptySet()
 
     override fun bind(
-        scope: Scope,
+        dynamicScope: DynamicScope,
     ): Thunk<Value> = value.asThunk
 }

--- a/analyzer/src/main/kotlin/com/github/cubuspl42/sigmaLang/analyzer/semantics/expressions/IsUndefinedCheck.kt
+++ b/analyzer/src/main/kotlin/com/github/cubuspl42/sigmaLang/analyzer/semantics/expressions/IsUndefinedCheck.kt
@@ -9,7 +9,6 @@ import com.github.cubuspl42.sigmaLang.analyzer.semantics.SemanticError
 import com.github.cubuspl42.sigmaLang.analyzer.semantics.StaticScope
 import com.github.cubuspl42.sigmaLang.analyzer.semantics.types.BoolType
 import com.github.cubuspl42.sigmaLang.analyzer.semantics.types.Type
-import com.github.cubuspl42.sigmaLang.analyzer.syntax.expressions.IsUndefinedCheckSourceTerm
 import com.github.cubuspl42.sigmaLang.analyzer.syntax.expressions.IsUndefinedCheckTerm
 
 data class IsUndefinedCheck(

--- a/analyzer/src/main/kotlin/com/github/cubuspl42/sigmaLang/analyzer/semantics/expressions/IsUndefinedCheck.kt
+++ b/analyzer/src/main/kotlin/com/github/cubuspl42/sigmaLang/analyzer/semantics/expressions/IsUndefinedCheck.kt
@@ -1,6 +1,6 @@
 package com.github.cubuspl42.sigmaLang.analyzer.semantics.expressions
 
-import com.github.cubuspl42.sigmaLang.analyzer.evaluation.scope.Scope
+import com.github.cubuspl42.sigmaLang.analyzer.evaluation.scope.DynamicScope
 import com.github.cubuspl42.sigmaLang.analyzer.evaluation.values.BoolValue
 import com.github.cubuspl42.sigmaLang.analyzer.evaluation.values.Thunk
 import com.github.cubuspl42.sigmaLang.analyzer.evaluation.values.UndefinedValue
@@ -32,8 +32,8 @@ data class IsUndefinedCheck(
     }
 
     override val inferredType: Thunk<Type> = Thunk.pure(BoolType)
-    override fun bind(scope: Scope): Thunk<Value> = argument.bind(
-        scope = scope,
+    override fun bind(dynamicScope: DynamicScope): Thunk<Value> = argument.bind(
+        dynamicScope = dynamicScope,
     ).thenJust { argumentValue ->
         BoolValue(
             value = argumentValue is UndefinedValue,

--- a/analyzer/src/main/kotlin/com/github/cubuspl42/sigmaLang/analyzer/semantics/expressions/LetExpression.kt
+++ b/analyzer/src/main/kotlin/com/github/cubuspl42/sigmaLang/analyzer/semantics/expressions/LetExpression.kt
@@ -7,7 +7,6 @@ import com.github.cubuspl42.sigmaLang.analyzer.semantics.LocalValueDefinitionBlo
 import com.github.cubuspl42.sigmaLang.analyzer.semantics.SemanticError
 import com.github.cubuspl42.sigmaLang.analyzer.semantics.StaticScope
 import com.github.cubuspl42.sigmaLang.analyzer.semantics.types.Type
-import com.github.cubuspl42.sigmaLang.analyzer.syntax.expressions.LetExpressionSourceTerm
 import com.github.cubuspl42.sigmaLang.analyzer.syntax.expressions.LetExpressionTerm
 
 data class LetExpression(

--- a/analyzer/src/main/kotlin/com/github/cubuspl42/sigmaLang/analyzer/semantics/expressions/LetExpression.kt
+++ b/analyzer/src/main/kotlin/com/github/cubuspl42/sigmaLang/analyzer/semantics/expressions/LetExpression.kt
@@ -1,6 +1,6 @@
 package com.github.cubuspl42.sigmaLang.analyzer.semantics.expressions
 
-import com.github.cubuspl42.sigmaLang.analyzer.evaluation.scope.Scope
+import com.github.cubuspl42.sigmaLang.analyzer.evaluation.scope.DynamicScope
 import com.github.cubuspl42.sigmaLang.analyzer.evaluation.values.Thunk
 import com.github.cubuspl42.sigmaLang.analyzer.evaluation.values.Value
 import com.github.cubuspl42.sigmaLang.analyzer.semantics.LocalValueDefinitionBlock
@@ -52,9 +52,9 @@ data class LetExpression(
     override val inferredType: Thunk<Type>
         get() = result.inferredType
 
-    override fun bind(scope: Scope): Thunk<Value> = result.bind(
-        scope = definitionBlock.evaluate(
-            scope = scope,
+    override fun bind(dynamicScope: DynamicScope): Thunk<Value> = result.bind(
+        dynamicScope = definitionBlock.evaluate(
+            dynamicScope = dynamicScope,
         ),
     )
 

--- a/analyzer/src/main/kotlin/com/github/cubuspl42/sigmaLang/analyzer/semantics/expressions/OrderedTupleConstructor.kt
+++ b/analyzer/src/main/kotlin/com/github/cubuspl42/sigmaLang/analyzer/semantics/expressions/OrderedTupleConstructor.kt
@@ -1,6 +1,6 @@
 package com.github.cubuspl42.sigmaLang.analyzer.semantics.expressions
 
-import com.github.cubuspl42.sigmaLang.analyzer.evaluation.scope.Scope
+import com.github.cubuspl42.sigmaLang.analyzer.evaluation.scope.DynamicScope
 import com.github.cubuspl42.sigmaLang.analyzer.evaluation.values.ArrayTable
 import com.github.cubuspl42.sigmaLang.analyzer.evaluation.values.Thunk
 import com.github.cubuspl42.sigmaLang.analyzer.evaluation.values.Value
@@ -53,9 +53,9 @@ class OrderedTupleConstructor(
     }
 
     override fun bind(
-        scope: Scope,
+        dynamicScope: DynamicScope,
     ): Thunk<Value> = Thunk.traverseList(elements) {
-        it.bind(scope = scope)
+        it.bind(dynamicScope = dynamicScope)
     }.thenJust { elements ->
         ArrayTable(elements = elements)
     }

--- a/analyzer/src/main/kotlin/com/github/cubuspl42/sigmaLang/analyzer/semantics/expressions/OrderedTupleConstructor.kt
+++ b/analyzer/src/main/kotlin/com/github/cubuspl42/sigmaLang/analyzer/semantics/expressions/OrderedTupleConstructor.kt
@@ -7,7 +7,6 @@ import com.github.cubuspl42.sigmaLang.analyzer.evaluation.values.Value
 import com.github.cubuspl42.sigmaLang.analyzer.semantics.SemanticError
 import com.github.cubuspl42.sigmaLang.analyzer.semantics.StaticScope
 import com.github.cubuspl42.sigmaLang.analyzer.semantics.types.OrderedTupleType
-import com.github.cubuspl42.sigmaLang.analyzer.syntax.expressions.OrderedTupleConstructorSourceTerm
 import com.github.cubuspl42.sigmaLang.analyzer.syntax.expressions.OrderedTupleConstructorTerm
 
 class OrderedTupleConstructor(

--- a/analyzer/src/main/kotlin/com/github/cubuspl42/sigmaLang/analyzer/semantics/expressions/OrderedTupleTypeConstructor.kt
+++ b/analyzer/src/main/kotlin/com/github/cubuspl42/sigmaLang/analyzer/semantics/expressions/OrderedTupleTypeConstructor.kt
@@ -1,6 +1,6 @@
 package com.github.cubuspl42.sigmaLang.analyzer.semantics.expressions
 
-import com.github.cubuspl42.sigmaLang.analyzer.evaluation.scope.Scope
+import com.github.cubuspl42.sigmaLang.analyzer.evaluation.scope.DynamicScope
 import com.github.cubuspl42.sigmaLang.analyzer.evaluation.values.Symbol
 import com.github.cubuspl42.sigmaLang.analyzer.evaluation.values.Thunk
 import com.github.cubuspl42.sigmaLang.analyzer.evaluation.values.Value
@@ -43,9 +43,9 @@ class OrderedTupleTypeConstructor(
         get() = TODO()
 
     override fun bind(
-        scope: Scope,
+        dynamicScope: DynamicScope,
     ): Thunk<Value> = Thunk.traverseList(elements) { element ->
-        element.type.bind(scope = scope).thenJust { elementType ->
+        element.type.bind(dynamicScope = dynamicScope).thenJust { elementType ->
             OrderedTupleType.Element(
                 name = element.name, type = elementType as Type,
             )

--- a/analyzer/src/main/kotlin/com/github/cubuspl42/sigmaLang/analyzer/semantics/expressions/Reference.kt
+++ b/analyzer/src/main/kotlin/com/github/cubuspl42/sigmaLang/analyzer/semantics/expressions/Reference.kt
@@ -1,6 +1,6 @@
 package com.github.cubuspl42.sigmaLang.analyzer.semantics.expressions
 
-import com.github.cubuspl42.sigmaLang.analyzer.evaluation.scope.Scope
+import com.github.cubuspl42.sigmaLang.analyzer.evaluation.scope.DynamicScope
 import com.github.cubuspl42.sigmaLang.analyzer.semantics.StaticScope
 import com.github.cubuspl42.sigmaLang.analyzer.semantics.SemanticError
 import com.github.cubuspl42.sigmaLang.analyzer.semantics.types.IllType
@@ -48,7 +48,7 @@ class Reference(
 
     override val subExpressions: Set<Expression> = emptySet()
 
-    override fun bind(scope: Scope): Thunk<Value> = scope.getValue(
+    override fun bind(dynamicScope: DynamicScope): Thunk<Value> = dynamicScope.getValue(
         name = referredName,
     ) ?: throw RuntimeException(
         "Unresolved reference at run-time: $referredName",

--- a/analyzer/src/main/kotlin/com/github/cubuspl42/sigmaLang/analyzer/semantics/expressions/SetConstructor.kt
+++ b/analyzer/src/main/kotlin/com/github/cubuspl42/sigmaLang/analyzer/semantics/expressions/SetConstructor.kt
@@ -1,6 +1,6 @@
 package com.github.cubuspl42.sigmaLang.analyzer.semantics.expressions
 
-import com.github.cubuspl42.sigmaLang.analyzer.evaluation.scope.Scope
+import com.github.cubuspl42.sigmaLang.analyzer.evaluation.scope.DynamicScope
 import com.github.cubuspl42.sigmaLang.analyzer.evaluation.values.SetValue
 import com.github.cubuspl42.sigmaLang.analyzer.evaluation.values.Thunk
 import com.github.cubuspl42.sigmaLang.analyzer.evaluation.values.Value
@@ -77,9 +77,9 @@ class SetConstructor(
     override val subExpressions: Set<Expression> = elements
 
     override fun bind(
-        scope: Scope,
+        dynamicScope: DynamicScope,
     ): Thunk<Value> = Thunk.traverseList(elements.toList()) {
-        it.bind(scope = scope)
+        it.bind(dynamicScope = dynamicScope)
     }.thenJust { elements ->
         SetValue(
             elements = elements.toSet(),

--- a/analyzer/src/main/kotlin/com/github/cubuspl42/sigmaLang/analyzer/semantics/expressions/SetConstructor.kt
+++ b/analyzer/src/main/kotlin/com/github/cubuspl42/sigmaLang/analyzer/semantics/expressions/SetConstructor.kt
@@ -10,7 +10,6 @@ import com.github.cubuspl42.sigmaLang.analyzer.semantics.types.IllType
 import com.github.cubuspl42.sigmaLang.analyzer.semantics.types.SetType
 import com.github.cubuspl42.sigmaLang.analyzer.semantics.types.Type
 import com.github.cubuspl42.sigmaLang.analyzer.syntax.SourceLocation
-import com.github.cubuspl42.sigmaLang.analyzer.syntax.expressions.SetConstructorSourceTerm
 import com.github.cubuspl42.sigmaLang.analyzer.syntax.expressions.SetConstructorTerm
 
 class SetConstructor(

--- a/analyzer/src/main/kotlin/com/github/cubuspl42/sigmaLang/analyzer/semantics/expressions/TranslationDynamicScope.kt
+++ b/analyzer/src/main/kotlin/com/github/cubuspl42/sigmaLang/analyzer/semantics/expressions/TranslationDynamicScope.kt
@@ -1,6 +1,6 @@
 package com.github.cubuspl42.sigmaLang.analyzer.semantics.expressions
 
-import com.github.cubuspl42.sigmaLang.analyzer.evaluation.scope.Scope
+import com.github.cubuspl42.sigmaLang.analyzer.evaluation.scope.DynamicScope
 import com.github.cubuspl42.sigmaLang.analyzer.evaluation.values.Symbol
 import com.github.cubuspl42.sigmaLang.analyzer.evaluation.values.Thunk
 import com.github.cubuspl42.sigmaLang.analyzer.evaluation.values.Value
@@ -12,9 +12,9 @@ import com.github.cubuspl42.sigmaLang.analyzer.semantics.StaticScope
 import com.github.cubuspl42.sigmaLang.analyzer.semantics.types.MetaType
 import com.github.cubuspl42.sigmaLang.analyzer.semantics.types.TypeVariable
 
-class TranslationScope(
+class TranslationDynamicScope(
     private val staticScope: StaticScope,
-) : Scope {
+) : DynamicScope {
     override fun getValue(
         name: Symbol,
     ): Thunk<Value>? = staticScope.resolveName(

--- a/analyzer/src/main/kotlin/com/github/cubuspl42/sigmaLang/analyzer/semantics/expressions/UnorderedTupleConstructor.kt
+++ b/analyzer/src/main/kotlin/com/github/cubuspl42/sigmaLang/analyzer/semantics/expressions/UnorderedTupleConstructor.kt
@@ -1,6 +1,6 @@
 package com.github.cubuspl42.sigmaLang.analyzer.semantics.expressions
 
-import com.github.cubuspl42.sigmaLang.analyzer.evaluation.scope.Scope
+import com.github.cubuspl42.sigmaLang.analyzer.evaluation.scope.DynamicScope
 import com.github.cubuspl42.sigmaLang.analyzer.evaluation.values.*
 import com.github.cubuspl42.sigmaLang.analyzer.semantics.SemanticError
 import com.github.cubuspl42.sigmaLang.analyzer.semantics.StaticScope
@@ -93,9 +93,9 @@ class UnorderedTupleConstructor(
     }
 
     override fun bind(
-        scope: Scope,
+        dynamicScope: DynamicScope,
     ): Thunk<Value> = Thunk.traverseList(entries.toList()) { entry ->
-        entry.value.bind(scope = scope).thenJust { entryValue ->
+        entry.value.bind(dynamicScope = dynamicScope).thenJust { entryValue ->
             entry.name to entryValue
         }
     }.thenJust { entries ->

--- a/analyzer/src/main/kotlin/com/github/cubuspl42/sigmaLang/analyzer/semantics/expressions/UnorderedTupleTypeConstructor.kt
+++ b/analyzer/src/main/kotlin/com/github/cubuspl42/sigmaLang/analyzer/semantics/expressions/UnorderedTupleTypeConstructor.kt
@@ -1,6 +1,6 @@
 package com.github.cubuspl42.sigmaLang.analyzer.semantics.expressions
 
-import com.github.cubuspl42.sigmaLang.analyzer.evaluation.scope.Scope
+import com.github.cubuspl42.sigmaLang.analyzer.evaluation.scope.DynamicScope
 import com.github.cubuspl42.sigmaLang.analyzer.evaluation.values.Symbol
 import com.github.cubuspl42.sigmaLang.analyzer.evaluation.values.Thunk
 import com.github.cubuspl42.sigmaLang.analyzer.evaluation.values.Value
@@ -55,10 +55,10 @@ class UnorderedTupleTypeConstructor(
     override val inferredType: Thunk<Type> = MetaType.asThunk
 
     override fun bind(
-        scope: Scope,
+        dynamicScope: DynamicScope,
     ): Thunk<Value> = Thunk.traverseList(entries.toList()) { entry ->
         entry.type.bind(
-            scope = scope,
+            dynamicScope = dynamicScope,
         ).thenJust { entryType ->
             entry.name to (entryType as Type)
         }

--- a/analyzer/src/main/kotlin/com/github/cubuspl42/sigmaLang/analyzer/semantics/expressions/UnorderedTupleTypeConstructor.kt
+++ b/analyzer/src/main/kotlin/com/github/cubuspl42/sigmaLang/analyzer/semantics/expressions/UnorderedTupleTypeConstructor.kt
@@ -10,7 +10,6 @@ import com.github.cubuspl42.sigmaLang.analyzer.semantics.StaticScope
 import com.github.cubuspl42.sigmaLang.analyzer.semantics.types.MetaType
 import com.github.cubuspl42.sigmaLang.analyzer.semantics.types.Type
 import com.github.cubuspl42.sigmaLang.analyzer.semantics.types.UnorderedTupleType
-import com.github.cubuspl42.sigmaLang.analyzer.syntax.expressions.UnorderedTupleConstructorTerm
 import com.github.cubuspl42.sigmaLang.analyzer.syntax.expressions.UnorderedTupleTypeConstructorTerm
 
 class UnorderedTupleTypeConstructor(

--- a/analyzer/src/main/kotlin/com/github/cubuspl42/sigmaLang/analyzer/semantics/types/OrderedTupleType.kt
+++ b/analyzer/src/main/kotlin/com/github/cubuspl42/sigmaLang/analyzer/semantics/types/OrderedTupleType.kt
@@ -1,7 +1,7 @@
 package com.github.cubuspl42.sigmaLang.analyzer.semantics.types
 
 import indexOfOrNull
-import com.github.cubuspl42.sigmaLang.analyzer.evaluation.scope.Scope
+import com.github.cubuspl42.sigmaLang.analyzer.evaluation.scope.DynamicScope
 import com.github.cubuspl42.sigmaLang.analyzer.evaluation.values.IntValue
 import com.github.cubuspl42.sigmaLang.analyzer.semantics.expressions.Abstraction
 import com.github.cubuspl42.sigmaLang.analyzer.evaluation.values.Symbol
@@ -167,7 +167,7 @@ data class OrderedTupleType(
         )
     }
 
-    override fun toArgumentScope(argument: DictValue): Scope = object : Scope {
+    override fun toArgumentScope(argument: DictValue): DynamicScope = object : DynamicScope {
         override fun getValue(name: Symbol): Thunk<Value>? {
             val index = elements.indexOfOrNull { it.name == name } ?: return null
 

--- a/analyzer/src/main/kotlin/com/github/cubuspl42/sigmaLang/analyzer/semantics/types/TupleType.kt
+++ b/analyzer/src/main/kotlin/com/github/cubuspl42/sigmaLang/analyzer/semantics/types/TupleType.kt
@@ -1,6 +1,6 @@
 package com.github.cubuspl42.sigmaLang.analyzer.semantics.types
 
-import com.github.cubuspl42.sigmaLang.analyzer.evaluation.scope.Scope
+import com.github.cubuspl42.sigmaLang.analyzer.evaluation.scope.DynamicScope
 import com.github.cubuspl42.sigmaLang.analyzer.evaluation.values.DictValue
 import com.github.cubuspl42.sigmaLang.analyzer.semantics.expressions.Abstraction
 
@@ -11,5 +11,5 @@ abstract class TupleType : TableType() {
         resolution: TypeVariableResolution,
     ): TupleType
 
-    abstract fun toArgumentScope(argument: DictValue): Scope
+    abstract fun toArgumentScope(argument: DictValue): DynamicScope
 }

--- a/analyzer/src/main/kotlin/com/github/cubuspl42/sigmaLang/analyzer/semantics/types/UnorderedTupleType.kt
+++ b/analyzer/src/main/kotlin/com/github/cubuspl42/sigmaLang/analyzer/semantics/types/UnorderedTupleType.kt
@@ -1,6 +1,6 @@
 package com.github.cubuspl42.sigmaLang.analyzer.semantics.types
 
-import com.github.cubuspl42.sigmaLang.analyzer.evaluation.scope.Scope
+import com.github.cubuspl42.sigmaLang.analyzer.evaluation.scope.DynamicScope
 import com.github.cubuspl42.sigmaLang.analyzer.evaluation.values.Symbol
 import com.github.cubuspl42.sigmaLang.analyzer.evaluation.values.DictValue
 import com.github.cubuspl42.sigmaLang.analyzer.evaluation.values.Thunk
@@ -141,7 +141,7 @@ data class UnorderedTupleType(
         },
     )
 
-    override fun toArgumentScope(argument: DictValue): Scope = object : Scope {
+    override fun toArgumentScope(argument: DictValue): DynamicScope = object : DynamicScope {
         override fun getValue(
             name: Symbol,
         ): Thunk<Value>? = argument.read(name)?.asThunk

--- a/analyzer/src/main/kotlin/com/github/cubuspl42/sigmaLang/analyzer/syntax/ImportSourceTerm.kt
+++ b/analyzer/src/main/kotlin/com/github/cubuspl42/sigmaLang/analyzer/syntax/ImportSourceTerm.kt
@@ -1,0 +1,38 @@
+package com.github.cubuspl42.sigmaLang.analyzer.syntax
+
+import com.github.cubuspl42.sigmaLang.analyzer.parser.antlr.SigmaParser
+import com.github.cubuspl42.sigmaLang.analyzer.parser.antlr.SigmaParser.ImportStatementContext
+import com.github.cubuspl42.sigmaLang.analyzer.semantics.ModulePath
+
+data class ImportSourceTerm(
+    override val location: SourceLocation,
+    override val modulePath: ModulePath,
+) : SourceTerm(), ImportTerm {
+    companion object {
+        fun parse(
+            source: String,
+        ): ImportSourceTerm = SourceTerm.parse(
+            source = source,
+            sourceName = "__import__",
+            rule = SigmaParser::importStatement,
+            build = ::build,
+        )
+
+        fun build(
+            ctx: ImportStatementContext,
+        ): ImportSourceTerm {
+            val importPathCtx = ctx.importPath()
+
+            if (importPathCtx.packagePathSegment.isNotEmpty()) {
+                throw IllegalArgumentException()
+            }
+
+            return ImportSourceTerm(
+                location = SourceLocation.build(ctx),
+                modulePath = ModulePath(
+                    name = importPathCtx.moduleName.text,
+                ),
+            )
+        }
+    }
+}

--- a/analyzer/src/main/kotlin/com/github/cubuspl42/sigmaLang/analyzer/syntax/ImportTerm.kt
+++ b/analyzer/src/main/kotlin/com/github/cubuspl42/sigmaLang/analyzer/syntax/ImportTerm.kt
@@ -1,0 +1,7 @@
+package com.github.cubuspl42.sigmaLang.analyzer.syntax
+
+import com.github.cubuspl42.sigmaLang.analyzer.semantics.ModulePath
+
+interface ImportTerm {
+    val modulePath: ModulePath
+}

--- a/analyzer/src/main/kotlin/com/github/cubuspl42/sigmaLang/analyzer/syntax/SourceTerm.kt
+++ b/analyzer/src/main/kotlin/com/github/cubuspl42/sigmaLang/analyzer/syntax/SourceTerm.kt
@@ -1,5 +1,26 @@
 package com.github.cubuspl42.sigmaLang.analyzer.syntax
 
+import com.github.cubuspl42.sigmaLang.analyzer.parser.antlr.SigmaLexer
+import com.github.cubuspl42.sigmaLang.analyzer.parser.antlr.SigmaParser
+import org.antlr.v4.runtime.CharStreams
+import org.antlr.v4.runtime.CommonTokenStream
+import org.antlr.v4.runtime.ParserRuleContext
+
 abstract class SourceTerm {
+    companion object {
+        fun <T : SourceTerm, R : ParserRuleContext> parse(
+            source: String,
+            sourceName: String,
+            rule: (SigmaParser) -> R,
+            build: (R) -> T,
+        ): T {
+            val lexer = SigmaLexer(CharStreams.fromString(source, sourceName))
+            val tokenStream = CommonTokenStream(lexer)
+            val parser = SigmaParser(tokenStream)
+
+            return build(rule(parser))
+        }
+    }
+
     abstract val location: SourceLocation
 }

--- a/analyzer/src/main/kotlin/main.kt
+++ b/analyzer/src/main/kotlin/main.kt
@@ -1,13 +1,17 @@
 import com.github.cubuspl42.sigmaLang.analyzer.evaluation.values.EvaluationError
 import com.github.cubuspl42.sigmaLang.analyzer.evaluation.values.EvaluationResult
 import com.github.cubuspl42.sigmaLang.analyzer.semantics.Project
+import com.github.cubuspl42.sigmaLang.analyzer.semantics.ResourceProjectStore
 
 fun main() {
-    val store = Project.ResourceStore(javaClass = object {}.javaClass)
-    val loader = Project.Loader.create(store = store)
-    val program = loader.load(fileBaseName = "problem")
+    val projectStore = ResourceProjectStore(javaClass = object {}.javaClass)
+    val projectLoader = Project.Loader.create()
+    val project = projectLoader.load(
+        projectStore = projectStore,
+        mainModuleName = "problem",
+    )
 
-    when (val outcome = program.evaluateResult()) {
+    when (val outcome = project.entryPoint.evaluateResult()) {
         is EvaluationError -> println("Error: $outcome")
         is EvaluationResult -> println("Result: ${outcome.value.dump()}")
     }

--- a/analyzer/src/test/kotlin/com/github/cubuspl42/sigmaLang/analyzer/semantics/ModuleTests.kt
+++ b/analyzer/src/test/kotlin/com/github/cubuspl42/sigmaLang/analyzer/semantics/ModuleTests.kt
@@ -27,7 +27,7 @@ class ModuleTests {
                 term = term,
             )
 
-            val isUserIdValid = module.rootNamespace.getConstantDefinition(
+            val isUserIdValid = module.rootNamespace.getEntry(
                 name = Symbol.of("isUserIdValid"),
             )
 
@@ -45,7 +45,7 @@ class ModuleTests {
                     ),
                     imageType = BoolType,
                 ),
-                actual = isUserIdValid.asValueDefinition.effectiveValueType.value,
+                actual = isUserIdValid.effectiveType.value,
             )
         }
     }

--- a/analyzer/src/test/kotlin/com/github/cubuspl42/sigmaLang/analyzer/semantics/NamespaceTests.kt
+++ b/analyzer/src/test/kotlin/com/github/cubuspl42/sigmaLang/analyzer/semantics/NamespaceTests.kt
@@ -29,7 +29,7 @@ class NamespaceTests {
                 term = term,
             )
 
-            val isUserIdValidDefinition = namespace.getConstantDefinition(
+            val isUserIdValidDefinition = namespace.getEntry(
                 name = Symbol.of("isUserIdValid"),
             )
 
@@ -47,7 +47,7 @@ class NamespaceTests {
                     ),
                     imageType = BoolType,
                 ),
-                actual = isUserIdValidDefinition.asValueDefinition.effectiveValueType.value,
+                actual = isUserIdValidDefinition.effectiveType.value,
             )
         }
     }

--- a/analyzer/src/test/kotlin/com/github/cubuspl42/sigmaLang/analyzer/semantics/expressions/AbstractionTests.kt
+++ b/analyzer/src/test/kotlin/com/github/cubuspl42/sigmaLang/analyzer/semantics/expressions/AbstractionTests.kt
@@ -147,7 +147,7 @@ class AbstractionTests {
 
             val result = assertIs<EvaluationResult<Value>>(
                 abstraction.bind(
-                    scope = BuiltinScope,
+                    dynamicScope = BuiltinScope,
                 ).evaluateInitial(),
             )
 

--- a/analyzer/src/test/kotlin/com/github/cubuspl42/sigmaLang/analyzer/semantics/expressions/CallTests.kt
+++ b/analyzer/src/test/kotlin/com/github/cubuspl42/sigmaLang/analyzer/semantics/expressions/CallTests.kt
@@ -1,6 +1,6 @@
 package com.github.cubuspl42.sigmaLang.analyzer.semantics.expressions
 
-import com.github.cubuspl42.sigmaLang.analyzer.evaluation.scope.FixedScope
+import com.github.cubuspl42.sigmaLang.analyzer.evaluation.scope.FixedDynamicScope
 import com.github.cubuspl42.sigmaLang.analyzer.evaluation.values.ComputableFunctionValue
 import com.github.cubuspl42.sigmaLang.analyzer.evaluation.values.DictValue
 import com.github.cubuspl42.sigmaLang.analyzer.evaluation.values.IntValue
@@ -341,7 +341,7 @@ class CallTests {
 
             val result = assertIs<EvaluationResult<Value>>(
                 call.bind(
-                    scope = FixedScope(
+                    dynamicScope = FixedDynamicScope(
                         entries = mapOf(
                             Symbol.of("sq") to sq,
                         )
@@ -363,7 +363,7 @@ class CallTests {
 
             val result = assertIs<EvaluationResult<Value>>(
                 call.bind(
-                    scope = FixedScope(
+                    dynamicScope = FixedDynamicScope(
                         entries = mapOf(
                             Symbol.of("dict") to DictValue(
                                 entries = mapOf(

--- a/analyzer/src/test/kotlin/com/github/cubuspl42/sigmaLang/analyzer/semantics/expressions/FieldReadTests.kt
+++ b/analyzer/src/test/kotlin/com/github/cubuspl42/sigmaLang/analyzer/semantics/expressions/FieldReadTests.kt
@@ -1,6 +1,6 @@
 package com.github.cubuspl42.sigmaLang.analyzer.semantics.expressions
 
-import com.github.cubuspl42.sigmaLang.analyzer.evaluation.scope.FixedScope
+import com.github.cubuspl42.sigmaLang.analyzer.evaluation.scope.FixedDynamicScope
 import com.github.cubuspl42.sigmaLang.analyzer.evaluation.values.IntValue
 import com.github.cubuspl42.sigmaLang.analyzer.evaluation.values.Symbol
 import com.github.cubuspl42.sigmaLang.analyzer.evaluation.values.DictValue
@@ -31,7 +31,7 @@ class FieldReadTests {
 
             val result = assertIs<EvaluationResult<Value>>(
                 fieldRead.bind(
-                    scope = FixedScope(
+                    dynamicScope = FixedDynamicScope(
                         entries = mapOf(
                             Symbol.of("foo") to foo,
                         )

--- a/analyzer/src/test/kotlin/com/github/cubuspl42/sigmaLang/analyzer/semantics/expressions/IfExpressionTests.kt
+++ b/analyzer/src/test/kotlin/com/github/cubuspl42/sigmaLang/analyzer/semantics/expressions/IfExpressionTests.kt
@@ -95,7 +95,7 @@ class IfExpressionTests {
 
             val result = assertIs<EvaluationResult<Value>>(
                 ifExpression.bind(
-                    scope = BuiltinScope,
+                    dynamicScope = BuiltinScope,
                 ).evaluateInitial(),
             )
 
@@ -123,7 +123,7 @@ class IfExpressionTests {
 
             val result = assertIs<EvaluationResult<Value>>(
                 ifExpression.bind(
-                    scope = BuiltinScope,
+                    dynamicScope = BuiltinScope,
                 ).evaluateInitial(),
             )
 

--- a/analyzer/src/test/kotlin/com/github/cubuspl42/sigmaLang/analyzer/semantics/expressions/IntLiteralTests.kt
+++ b/analyzer/src/test/kotlin/com/github/cubuspl42/sigmaLang/analyzer/semantics/expressions/IntLiteralTests.kt
@@ -1,6 +1,6 @@
 package com.github.cubuspl42.sigmaLang.analyzer.semantics.expressions
 
-import com.github.cubuspl42.sigmaLang.analyzer.evaluation.scope.Scope
+import com.github.cubuspl42.sigmaLang.analyzer.evaluation.scope.DynamicScope
 import com.github.cubuspl42.sigmaLang.analyzer.evaluation.values.IntValue
 import com.github.cubuspl42.sigmaLang.analyzer.evaluation.values.EvaluationResult
 import com.github.cubuspl42.sigmaLang.analyzer.evaluation.values.Value
@@ -22,7 +22,7 @@ class IntLiteralTests {
 
             val result = assertIs<EvaluationResult<Value>>(
                 intLiteral.bind(
-                    scope = Scope.Empty,
+                    dynamicScope = DynamicScope.Empty,
                 ).evaluateInitial(),
             )
 

--- a/analyzer/src/test/kotlin/com/github/cubuspl42/sigmaLang/analyzer/semantics/expressions/IsUndefinedCheckTests.kt
+++ b/analyzer/src/test/kotlin/com/github/cubuspl42/sigmaLang/analyzer/semantics/expressions/IsUndefinedCheckTests.kt
@@ -1,7 +1,7 @@
 package com.github.cubuspl42.sigmaLang.analyzer.semantics.expressions
 
-import com.github.cubuspl42.sigmaLang.analyzer.evaluation.scope.FixedScope
-import com.github.cubuspl42.sigmaLang.analyzer.evaluation.scope.Scope
+import com.github.cubuspl42.sigmaLang.analyzer.evaluation.scope.FixedDynamicScope
+import com.github.cubuspl42.sigmaLang.analyzer.evaluation.scope.DynamicScope
 import com.github.cubuspl42.sigmaLang.analyzer.evaluation.values.BoolValue
 import com.github.cubuspl42.sigmaLang.analyzer.evaluation.values.Symbol
 import com.github.cubuspl42.sigmaLang.analyzer.evaluation.values.DictValue
@@ -47,7 +47,7 @@ class IsUndefinedCheckTests {
 
             val result = assertIs<EvaluationResult<Value>>(
                 isUndefinedCheck.bind(
-                    scope = Scope.Empty,
+                    dynamicScope = DynamicScope.Empty,
                 ).evaluateInitial(),
             )
 
@@ -70,7 +70,7 @@ class IsUndefinedCheckTests {
 
             val result = assertIs<EvaluationResult<Value>>(
                 isUndefinedCheck.bind(
-                    scope = FixedScope(
+                    dynamicScope = FixedDynamicScope(
                         entries = mapOf(
                             Symbol.of("d") to dictValue,
                         ),

--- a/analyzer/src/test/kotlin/com/github/cubuspl42/sigmaLang/analyzer/semantics/expressions/LetExpressionTests.kt
+++ b/analyzer/src/test/kotlin/com/github/cubuspl42/sigmaLang/analyzer/semantics/expressions/LetExpressionTests.kt
@@ -1,6 +1,6 @@
 package com.github.cubuspl42.sigmaLang.analyzer.semantics.expressions
 
-import com.github.cubuspl42.sigmaLang.analyzer.evaluation.scope.Scope
+import com.github.cubuspl42.sigmaLang.analyzer.evaluation.scope.DynamicScope
 import com.github.cubuspl42.sigmaLang.analyzer.evaluation.values.EvaluationStackExhaustionError
 import com.github.cubuspl42.sigmaLang.analyzer.semantics.BuiltinScope
 import com.github.cubuspl42.sigmaLang.analyzer.semantics.types.FunctionType
@@ -149,7 +149,7 @@ class LetExpressionTests {
             )
 
             assertIs<EvaluationStackExhaustionError>(
-                let.bind(scope = Scope.Empty).outcome,
+                let.bind(dynamicScope = DynamicScope.Empty).outcome,
             )
         }
     }

--- a/analyzer/src/test/kotlin/com/github/cubuspl42/sigmaLang/analyzer/semantics/expressions/OrderedTupleConstructorTests.kt
+++ b/analyzer/src/test/kotlin/com/github/cubuspl42/sigmaLang/analyzer/semantics/expressions/OrderedTupleConstructorTests.kt
@@ -1,7 +1,7 @@
 package com.github.cubuspl42.sigmaLang.analyzer.semantics.expressions
 
-import com.github.cubuspl42.sigmaLang.analyzer.evaluation.scope.FixedScope
-import com.github.cubuspl42.sigmaLang.analyzer.evaluation.scope.Scope
+import com.github.cubuspl42.sigmaLang.analyzer.evaluation.scope.FixedDynamicScope
+import com.github.cubuspl42.sigmaLang.analyzer.evaluation.scope.DynamicScope
 import com.github.cubuspl42.sigmaLang.analyzer.evaluation.values.BoolValue
 import com.github.cubuspl42.sigmaLang.analyzer.evaluation.values.IntValue
 import com.github.cubuspl42.sigmaLang.analyzer.evaluation.values.Symbol
@@ -92,7 +92,7 @@ class OrderedTupleConstructorTests {
 
             val value = tupleConstructor.evaluateValue(
                 context = EvaluationContext.Initial,
-                scope = Scope.Empty,
+                dynamicScope = DynamicScope.Empty,
             )
 
             assertIs<DictValue>(value)
@@ -116,7 +116,7 @@ class OrderedTupleConstructorTests {
 
             val value = tupleConstructor.evaluateValue(
                 context = EvaluationContext.Initial,
-                scope = FixedScope(
+                dynamicScope = FixedDynamicScope(
                     entries = mapOf(
                         Symbol.of("a") to BoolValue(false),
                         Symbol.of("b") to IntValue(1),

--- a/analyzer/src/test/kotlin/com/github/cubuspl42/sigmaLang/analyzer/semantics/expressions/SetConstructorTests.kt
+++ b/analyzer/src/test/kotlin/com/github/cubuspl42/sigmaLang/analyzer/semantics/expressions/SetConstructorTests.kt
@@ -1,6 +1,6 @@
 package com.github.cubuspl42.sigmaLang.analyzer.semantics.expressions
 
-import com.github.cubuspl42.sigmaLang.analyzer.evaluation.scope.FixedScope
+import com.github.cubuspl42.sigmaLang.analyzer.evaluation.scope.FixedDynamicScope
 import com.github.cubuspl42.sigmaLang.analyzer.evaluation.values.IntValue
 import com.github.cubuspl42.sigmaLang.analyzer.evaluation.values.SetValue
 import com.github.cubuspl42.sigmaLang.analyzer.evaluation.values.Symbol
@@ -124,7 +124,7 @@ class SetConstructorTests {
 
             val result = assertIs<EvaluationResult<Value>>(
                 setConstructor.bind(
-                    scope = FixedScope(
+                    dynamicScope = FixedDynamicScope(
                         entries = mapOf(
                             Symbol.of("foo") to IntValue(value = 1L),
                             Symbol.of("bar") to IntValue(value = 2L),

--- a/analyzer/src/test/kotlin/com/github/cubuspl42/sigmaLang/analyzer/syntax/ImportTermTests.kt
+++ b/analyzer/src/test/kotlin/com/github/cubuspl42/sigmaLang/analyzer/syntax/ImportTermTests.kt
@@ -1,0 +1,27 @@
+package com.github.cubuspl42.sigmaLang.analyzer.syntax
+
+import com.github.cubuspl42.sigmaLang.analyzer.semantics.ModulePath
+import org.junit.experimental.runners.Enclosed
+import org.junit.runner.RunWith
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+@RunWith(Enclosed::class)
+class ImportTermTests {
+    class ParsingTests {
+        @Test
+        fun test() {
+            val term = ImportSourceTerm.parse(
+                source = "%import utils".trimIndent()
+            )
+
+            assertEquals(
+                expected = ImportSourceTerm(
+                    location = SourceLocation(lineIndex = 1, columnIndex = 0),
+                    modulePath = ModulePath(name = "utils"),
+                ),
+                actual = term,
+            )
+        }
+    }
+}

--- a/analyzer/src/testIntegration/kotlin/tests/BuiltinsTests.kt
+++ b/analyzer/src/testIntegration/kotlin/tests/BuiltinsTests.kt
@@ -42,7 +42,7 @@ class BuiltinsTests {
 
         // Validate `mySet1`
 
-        val mySet1Definition = namespace.getConstantDefinition(
+        val mySet1Definition = namespace.getEntry(
             name = Symbol.of("mySet1"),
         )!!
 
@@ -50,7 +50,7 @@ class BuiltinsTests {
             expected = SetType(
                 elementType = IntCollectiveType,
             ),
-            actual = mySet1Definition.asValueDefinition.effectiveValueType.value,
+            actual = mySet1Definition.effectiveType.value,
         )
 
         assertEquals(
@@ -61,34 +61,34 @@ class BuiltinsTests {
                     IntValue(value = 3L),
                 ),
             ),
-            actual = mySet1Definition.staticValue.value,
+            actual = mySet1Definition.valueThunk.value,
         )
 
         // Validate `contains2`
 
-        val contains2Definition = namespace.getConstantDefinition(
+        val contains2Definition = namespace.getEntry(
             name = Symbol.of("contains2"),
         )!!
 
         assertEquals(
             expected = BoolValue(value = true),
-            actual = contains2Definition.staticValue.value,
+            actual = contains2Definition.valueThunk.value,
         )
 
         // Validate `contains5`
 
-        val contains5Definition = namespace.getConstantDefinition(
+        val contains5Definition = namespace.getEntry(
             name = Symbol.of("contains5"),
         )!!
 
         assertEquals(
             expected = BoolValue(value = false),
-            actual = contains5Definition.staticValue.value,
+            actual = contains5Definition.valueThunk.value,
         )
 
         // Validate `mySet2`
 
-        val mySet2Definition = namespace.getConstantDefinition(
+        val mySet2Definition = namespace.getEntry(
             name = Symbol.of("mySet2"),
         )!!
 
@@ -101,7 +101,7 @@ class BuiltinsTests {
                     IntValue(value = 4L),
                 ),
             ),
-            actual = mySet2Definition.staticValue.value,
+            actual = mySet2Definition.valueThunk.value,
         )
     }
 }

--- a/analyzer/src/testIntegration/kotlin/tests/ScenarioTests.kt
+++ b/analyzer/src/testIntegration/kotlin/tests/ScenarioTests.kt
@@ -60,7 +60,7 @@ class ScenarioTests {
 
         // Validate `Entry`
 
-        val entryTypeConstructorDefinition = namespace.getConstantDefinition(
+        val entryTypeConstructorDefinition = namespace.getEntry(
             name = Symbol.of("Entry"),
         )!!
 
@@ -76,7 +76,7 @@ class ScenarioTests {
                 ),
                 imageType = MetaType,
             ),
-            actual = entryTypeConstructorDefinition.asValueDefinition.effectiveValueType.value,
+            actual = entryTypeConstructorDefinition.effectiveType.value,
         )
 
         // Construct `Entry[Bool]` and validate it
@@ -105,7 +105,7 @@ class ScenarioTests {
 
         // Validate `entryOf`
 
-        val entryOfAbstractionDefinition = namespace.getConstantDefinition(
+        val entryOfAbstractionDefinition = namespace.getEntry(
             name = Symbol.of("entryOf"),
         )!!
 
@@ -127,12 +127,12 @@ class ScenarioTests {
                     ),
                 ),
             ),
-            actual = entryOfAbstractionDefinition.asValueDefinition.effectiveValueType.value,
+            actual = entryOfAbstractionDefinition.effectiveType.value,
         )
 
         // Validate `entryTrueOf`
 
-        val entryTrueOfAbstractionDefinition = namespace.getConstantDefinition(
+        val entryTrueOfAbstractionDefinition = namespace.getEntry(
             name = Symbol.of("entryTrueOf"),
         )!!
 
@@ -150,7 +150,7 @@ class ScenarioTests {
                     ),
                 ),
             ),
-            actual = entryTrueOfAbstractionDefinition.asValueDefinition.effectiveValueType.value,
+            actual = entryTrueOfAbstractionDefinition.effectiveType.value,
         )
     }
 
@@ -184,9 +184,9 @@ class ScenarioTests {
             actual = error.nonInferredTypeVariables,
         )
 
-        val aType = namespace.getConstantDefinition(
+        val aType = namespace.getEntry(
             name = Symbol.of("a"),
-        )!!.asValueDefinition.effectiveValueType.value
+        )!!.effectiveType.value
 
         assertEquals(
             expected = IllType,

--- a/analyzer/src/testIntegration/kotlin/tests/euler/EulerProblemsTests.kt
+++ b/analyzer/src/testIntegration/kotlin/tests/euler/EulerProblemsTests.kt
@@ -2,6 +2,7 @@ package tests.euler
 
 import com.github.cubuspl42.sigmaLang.analyzer.evaluation.values.*
 import com.github.cubuspl42.sigmaLang.analyzer.semantics.Project
+import com.github.cubuspl42.sigmaLang.analyzer.semantics.ResourceProjectStore
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertIs
@@ -102,11 +103,14 @@ class EulerProblemsTests {
 }
 
 private fun solveProblem(n: Int): EvaluationOutcome<Value> {
-    val store = Project.ResourceStore(javaClass = EulerProblemsTests::class.java)
-    val loader = Project.Loader.create(store = store)
-    val program = loader.load(fileBaseName = "problem$n")
+    val store = ResourceProjectStore(javaClass = EulerProblemsTests::class.java)
+    val loader = Project.Loader.create()
+    val project = loader.load(
+        projectStore = store,
+        mainModuleName = "problem$n",
+    )
 
-    val errors = program.errors
+    val errors = project.errors
 
     println()
     println("[Problem $n]")
@@ -119,18 +123,16 @@ private fun solveProblem(n: Int): EvaluationOutcome<Value> {
         }
     }
 
-    val result = program.evaluateResult()
+    val evaluationResult = project.entryPoint.evaluateResult()
 
-    println()
-
-    when (val evaluationResult = program.evaluateResult()) {
+    when (evaluationResult) {
         EvaluationStackExhaustionError -> println("Error: call stack exhausted")
         is EvaluationResult -> println("Result: ${evaluationResult.value.dump()}")
     }
 
     println()
 
-    return result
+    return evaluationResult
 }
 
 private fun getResourceAsText(


### PR DESCRIPTION
- Make `Project` class actually used
- Add a test for the `%import` syntax
- Rename `Scope` to `DynamicScope`
- Remove some unused imports
- Nuke `Namespace.getConstantDefinition`
- Namespace: Remove unused `Value` inheritance
