### PR TITLE
bump 1

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,7 +29,7 @@ jobs:
           distribution: "temurin"
 
       - name: Check commit messages
-        uses: GsActions/commit-message-checker@v1
+        uses: GsActions/commit-message-checker@v2
         with:
           pattern: "^(?!WIP).*$"
           error: "The first line cannot start with WIP"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,7 +23,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Setup Java JDK
-        uses: actions/setup-java@v3.4.1
+        uses: actions/setup-java@v3.13.0
         with:
           java-version: "17"
           distribution: "temurin"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,6 +39,6 @@ jobs:
           accessToken: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Build & test the Gradle project
-        uses: gradle/gradle-build-action@v2.4.2
+        uses: gradle/gradle-build-action@v2.8.1
         with:
           arguments: test

--- a/analyzer/build.gradle.kts
+++ b/analyzer/build.gradle.kts
@@ -20,7 +20,7 @@ configurations {
 }
 
 dependencies {
-    antlr("org.antlr:antlr4:4.13.0")
+    antlr("org.antlr:antlr4:4.13.1")
     implementation("org.jetbrains.kotlinx:kotlinx-serialization-json:1.6.0")
 
     testImplementation(kotlin("test"))

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -4,7 +4,7 @@ annotations = "24.0.1"
 
 # plugins
 kotlin = "1.9.10"
-changelog = "2.1.2"
+changelog = "2.2.0"
 gradleIntelliJPlugin = "1.15.0"
 qodana = "0.1.13"
 kover = "0.7.3"

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -18,4 +18,4 @@ gradleIntelliJPlugin = { id = "org.jetbrains.intellij", version.ref = "gradleInt
 kotlin = { id = "org.jetbrains.kotlin.jvm", version.ref = "kotlin" }
 kover = { id = "org.jetbrains.kotlinx.kover", version.ref = "kover" }
 qodana = { id = "org.jetbrains.qodana", version.ref = "qodana" }
-gradleVersions = { id = "com.github.ben-manes.versions", version = "0.47.0"}
+gradleVersions = { id = "com.github.ben-manes.versions", version = "0.48.0"}


### PR DESCRIPTION
- Bump actions/setup-java from 3.4.1 to 3.13.0
- Bump gradle/gradle-build-action from 2.4.2 to 2.8.1
- Bump GsActions/commit-message-checker from 1 to 2
- Bump com.github.ben-manes.versions from 0.47.0 to 0.48.0
- Bump org.jetbrains.changelog from 2.1.2 to 2.2.0
- Bump org.antlr:antlr4 from 4.13.0 to 4.13.1
