### PR TITLE
bump deps 1

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -8,7 +8,7 @@ kotlin = "1.9.10"
 changelog = "2.2.0"
 gradleIntelliJPlugin = "1.15.0"
 qodana = "0.1.13"
-kover = "0.7.3"
+kover = "0.7.4"
 
 [libraries]
 annotations = { group = "org.jetbrains", name = "annotations", version.ref = "annotations" }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -6,7 +6,7 @@ kotlinxSerialization = "1.6.0"
 # plugins
 kotlin = "1.9.20"
 changelog = "2.2.0"
-gradleIntelliJPlugin = "1.15.0"
+gradleIntelliJPlugin = "1.16.0"
 qodana = "0.1.13"
 kover = "0.7.4"
 

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -20,4 +20,4 @@ gradleIntelliJPlugin = { id = "org.jetbrains.intellij", version.ref = "gradleInt
 kotlin = { id = "org.jetbrains.kotlin.jvm", version.ref = "kotlin" }
 kover = { id = "org.jetbrains.kotlinx.kover", version.ref = "kover" }
 qodana = { id = "org.jetbrains.qodana", version.ref = "qodana" }
-gradleVersions = { id = "com.github.ben-manes.versions", version = "0.48.0"}
+gradleVersions = { id = "com.github.ben-manes.versions", version = "0.49.0"}

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -4,7 +4,7 @@ annotations = "24.0.1"
 kotlinxSerialization = "1.6.0"
 
 # plugins
-kotlin = "1.9.10"
+kotlin = "1.9.20"
 changelog = "2.2.0"
 gradleIntelliJPlugin = "1.15.0"
 qodana = "0.1.13"


### PR DESCRIPTION
- Bump org.jetbrains.kotlinx.kover from 0.7.3 to 0.7.4
- Bump com.github.ben-manes.versions from 0.48.0 to 0.49.0
- Bump org.jetbrains.kotlin.jvm from 1.9.10 to 1.9.20
- Bump org.jetbrains.intellij from 1.15.0 to 1.16.0
