### PR TITLE
bump dependencies 2

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,6 +39,6 @@ jobs:
           accessToken: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Build & test the Gradle project
-        uses: gradle/gradle-build-action@v2.9.0
+        uses: gradle/gradle-build-action@v2.11.1
         with:
           arguments: test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,7 +23,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Setup Java JDK
-        uses: actions/setup-java@v3.13.0
+        uses: actions/setup-java@v4.0.0
         with:
           java-version: "17"
           distribution: "temurin"

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -20,4 +20,4 @@ gradleIntelliJPlugin = { id = "org.jetbrains.intellij", version.ref = "gradleInt
 kotlin = { id = "org.jetbrains.kotlin.jvm", version.ref = "kotlin" }
 kover = { id = "org.jetbrains.kotlinx.kover", version.ref = "kover" }
 qodana = { id = "org.jetbrains.qodana", version.ref = "qodana" }
-gradleVersions = { id = "com.github.ben-manes.versions", version = "0.49.0"}
+gradleVersions = { id = "com.github.ben-manes.versions", version = "0.50.0"}

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -8,7 +8,7 @@ kotlin = "1.9.20"
 changelog = "2.2.0"
 gradleIntelliJPlugin = "1.16.0"
 qodana = "0.1.13"
-kover = "0.7.4"
+kover = "0.7.5"
 
 [libraries]
 annotations = { group = "org.jetbrains", name = "annotations", version.ref = "annotations" }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,6 +1,6 @@
 [versions]
 # libraries
-annotations = "24.0.1"
+annotations = "24.1.0"
 kotlinxSerialization = "1.6.0"
 
 # plugins

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,7 +1,7 @@
 [versions]
 # libraries
 annotations = "24.1.0"
-kotlinxSerialization = "1.6.0"
+kotlinxSerialization = "1.6.2"
 
 # plugins
 kotlin = "1.9.20"

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -4,7 +4,7 @@ annotations = "24.1.0"
 kotlinxSerialization = "1.6.2"
 
 # plugins
-kotlin = "1.9.20"
+kotlin = "1.9.22"
 changelog = "2.2.0"
 gradleIntelliJPlugin = "1.16.0"
 qodana = "0.1.13"


### PR DESCRIPTION
- Bump org.jetbrains:annotations from 24.0.1 to 24.1.0
- Bump org.jetbrains.kotlinx:kotlinx-serialization-json
- Bump org.jetbrains.kotlinx.kover from 0.7.4 to 0.7.5
- Bump com.github.ben-manes.versions from 0.49.0 to 0.50.0
- Bump actions/setup-java from 3.13.0 to 4.0.0
- Bump org.jetbrains.kotlin.jvm from 1.9.20 to 1.9.22
- Bump gradle/gradle-build-action from 2.9.0 to 2.11.1
